### PR TITLE
Add Adafruit Feather ESP32 V2 board

### DIFF
--- a/boards/adafruit_feather_esp32_v2.json
+++ b/boards/adafruit_feather_esp32_v2.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DADAFRUIT_FEATHER_ESP32_V2 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32",
+    "variant": "adafruit_feather_esp32_v2"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_board": "esp-wroom-32.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Adafruit Feather ESP32 V2",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://www.adafruit.com/product/5400",
+  "vendor": "Adafruit"
+}

--- a/boards/adafruit_feather_esp32_v2.json
+++ b/boards/adafruit_feather_esp32_v2.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DADAFRUIT_FEATHER_ESP32_V2 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw",
+    "extra_flags": "-DADAFRUIT_FEATHER_ESP32_V2 -DBOARD_HAS_PSRAM",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",


### PR DESCRIPTION
For https://github.com/espressif/arduino-esp32/tree/master/variants/adafruit_feather_esp32_v2 with the default settings from https://github.com/espressif/arduino-esp32/blob/68daea4a4a03ca0e10b84c3a34e40a371df11e69/boards.txt#L5725-L5794