### PR TITLE
remove generated old sdkconfig leftover

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -204,8 +204,8 @@ envs = [section.replace("env:", "") for section in config.sections() if section.
 for env_name in envs:
     #print(f"- {env_name}")
     try:
-        print("sdkconfig.{env_name}")
-        os.remove(join(env.subst("$PROJECT_DIR"),"sdkconfig.{env_name}"))
+        print(f"sdkconfig.{env_name}")
+        os.remove(join(env.subst("$PROJECT_DIR"), f"sdkconfig.{env_name}"))
     except:
         pass
 

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -192,6 +192,14 @@ def call_compile_libs():
     SConscript("espidf.py")
 
 if check_reinstall_frwrk() == True:
+    envs = [section.replace("env:", "") for section in config.sections() if section.startswith("env:")]
+    for env_name in envs:
+        file_path = join(env.subst("$PROJECT_DIR"), f"sdkconfig.{env_name}")
+        if exists(file_path):
+            print(f"Removing {file_path}")
+            os.remove(file_path)
+        else:
+            print(f"File {file_path} does not exist.")
     print("*** Reinstall Arduino framework ***")
     shutil.rmtree(platform.get_package_dir("framework-arduinoespressif32"))
     ARDUINO_FRMWRK_URL = str(platform.get_package_spec("framework-arduinoespressif32")).split("uri=",1)[1][:-1]
@@ -199,15 +207,6 @@ if check_reinstall_frwrk() == True:
     if flag_custom_sdkconfig == True:
         call_compile_libs()
         flag_custom_sdkconfig = False
-
-envs = [section.replace("env:", "") for section in config.sections() if section.startswith("env:")]
-for env_name in envs:
-    file_path = join(env.subst("$PROJECT_DIR"), f"sdkconfig.{env_name}")
-    if exists(file_path):
-        print(f"Removing {file_path}")
-        os.remove(file_path)
-    else:
-        print(f"File {file_path} does not exist.")
 
 FRAMEWORK_SDK_DIR = fs.to_unix_path(
     os.path.join(

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -200,6 +200,8 @@ if check_reinstall_frwrk() == True:
         call_compile_libs()
         flag_custom_sdkconfig = False
 
+all_envs = [section for section in config.sections() if section.startswith("env:")]
+print("********* ", all_envs)
 
 FRAMEWORK_SDK_DIR = fs.to_unix_path(
     os.path.join(

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -200,8 +200,9 @@ if check_reinstall_frwrk() == True:
         call_compile_libs()
         flag_custom_sdkconfig = False
 
-all_envs = [section for section in config.sections() if section.startswith("env:")]
-print("********* ", all_envs)
+envs = [section.replace("env:", "") for section in config.sections() if section.startswith("env:")]
+for env_name in envs:
+    print(f"- {env_name}")
 
 FRAMEWORK_SDK_DIR = fs.to_unix_path(
     os.path.join(

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -196,10 +196,7 @@ if check_reinstall_frwrk() == True:
     for env_name in envs:
         file_path = join(env.subst("$PROJECT_DIR"), f"sdkconfig.{env_name}")
         if exists(file_path):
-            print(f"Removing {file_path}")
             os.remove(file_path)
-        else:
-            print(f"File {file_path} does not exist.")
     print("*** Reinstall Arduino framework ***")
     shutil.rmtree(platform.get_package_dir("framework-arduinoespressif32"))
     ARDUINO_FRMWRK_URL = str(platform.get_package_spec("framework-arduinoespressif32")).split("uri=",1)[1][:-1]

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -29,7 +29,7 @@ import semantic_version
 import os
 import sys
 import shutil
-from os.path import join
+from os.path import join, exists
 
 from SCons.Script import COMMAND_LINE_TARGETS, DefaultEnvironment, SConscript
 from platformio import fs
@@ -202,12 +202,12 @@ if check_reinstall_frwrk() == True:
 
 envs = [section.replace("env:", "") for section in config.sections() if section.startswith("env:")]
 for env_name in envs:
-    #print(f"- {env_name}")
-    try:
-        print(f"sdkconfig.{env_name}")
-        os.remove(join(env.subst("$PROJECT_DIR"), f"sdkconfig.{env_name}"))
-    except:
-        pass
+    file_path = join(env.subst("$PROJECT_DIR"), f"sdkconfig.{env_name}")
+    if exists(file_path):
+        print(f"Removing {file_path}")
+        os.remove(file_path)
+    else:
+        print(f"File {file_path} does not exist.")
 
 FRAMEWORK_SDK_DIR = fs.to_unix_path(
     os.path.join(

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -202,7 +202,12 @@ if check_reinstall_frwrk() == True:
 
 envs = [section.replace("env:", "") for section in config.sections() if section.startswith("env:")]
 for env_name in envs:
-    print(f"- {env_name}")
+    #print(f"- {env_name}")
+    try:
+        print("sdkconfig.{env_name}")
+        os.remove(join(env.subst("$PROJECT_DIR"),"sdkconfig.{env_name}"))
+    except:
+        pass
 
 FRAMEWORK_SDK_DIR = fs.to_unix_path(
     os.path.join(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Automatically removes environment-specific configuration files before reinstalling the Arduino framework to ensure a clean setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->