### PR TITLE
Install actual OpenOCD via IDF Installer directly from github releases

### DIFF
--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -47,6 +47,7 @@ custom_component_remove = espressif/esp_hosted
 [env:esp32-c6-devkitc-1]
 platform = espressif32
 framework = arduino
+build_type = debug
 board = esp32-c6-devkitc-1
 monitor_speed = 115200
 custom_component_remove = espressif/esp_hosted

--- a/platform.json
+++ b/platform.json
@@ -85,8 +85,8 @@
     "tool-openocd-esp32": {
       "type": "debugger",
       "optional": true,
-      "owner": "platformio",
-      "version": "~2.1100.0"
+      "owner": "",
+      "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/openocd-v0.12.0-esp32-20250226.zip"
     },
     "tool-esp-rom-elfs": {
       "optional": true,

--- a/platform.json
+++ b/platform.json
@@ -76,6 +76,11 @@
       "owner": "tasmota",
       "version": "https://github.com/tasmota/esptool/releases/download/v4.8.9/esptool.zip"
     },
+    "tl-install": {
+      "optional": false,
+      "owner": "pioarduino",
+      "version": "https://github.com/pioarduino/esp_install/releases/download/v3.0.0/esp_install-v3.0.0.zip"
+    },
     "tool-dfuutil-arduino": {
       "type": "uploader",
       "optional": true,
@@ -84,7 +89,7 @@
     },
     "tool-openocd-esp32": {
       "type": "debugger",
-      "optional": true,
+      "optional": false,
       "owner": "",
       "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/openocd-v0.12.0-esp32-20250226.zip"
     },

--- a/platform.json
+++ b/platform.json
@@ -38,7 +38,7 @@
     "framework-espidf": {
       "type": "framework",
       "optional": true,
-      "owner": "Jason2866",
+      "owner": "tasmota",
       "version": "https://github.com/tasmota/esp-idf/releases/download/v5.4.1.250415/esp-idf-v5.4.1.zip"
     },
     "toolchain-xtensa-esp-elf": {
@@ -73,10 +73,12 @@
     },
     "tool-esptoolpy": {
       "type": "uploader",
+      "optional": true,
       "owner": "tasmota",
       "version": "https://github.com/tasmota/esptool/releases/download/v4.8.9/esptool.zip"
     },
     "tl-install": {
+      "type": "tool",
       "optional": false,
       "owner": "pioarduino",
       "version": "https://github.com/pioarduino/esp_install/releases/download/v5.0.0/esp_install-v5.0.0.zip"
@@ -90,16 +92,18 @@
     "tool-openocd-esp32": {
       "type": "debugger",
       "optional": false,
-      "owner": "",
+      "owner": "pioarduino",
       "version": "https://github.com/pioarduino/registry/releases/download/0.0.1/openocd-v0.12.0-esp32-20250226.zip"
     },
     "tool-esp-rom-elfs": {
+      "type": "tool",
       "optional": true,
       "owner": "platformio",
       "version": "0.0.1+20241011"
     },
     "tool-mklittlefs": {
       "type": "uploader",
+      "optional": true,
       "owner": "tasmota",
       "version": "^3.2.0"
     },
@@ -110,31 +114,37 @@
       "version": "~2.0.0"
     },
     "tool-cppcheck": {
+      "type": "tool",
       "optional": true,
       "owner": "platformio",
       "version": "~1.21100"
     },
     "tool-clangtidy": {
+      "type": "tool",
       "optional": true,
       "owner": "platformio",
       "version": "^1.190100.0"
     },
     "tool-pvs-studio": {
+      "type": "tool",
       "optional": true,
       "owner": "platformio",
       "version": "^7.18.59866"
     },
     "tool-cmake": {
+      "type": "tool",
       "optional": true,
       "owner": "platformio",
       "version": "~3.30.2"
     },
     "tool-ninja": {
+      "type": "tool",
       "optional": true,
       "owner": "platformio",
       "version": "^1.7.0"
     },
     "tool-scons": {
+      "type": "tool",
       "optional": true,
       "owner": "platformio",
       "version": "~4.40801.0"

--- a/platform.json
+++ b/platform.json
@@ -73,7 +73,7 @@
     },
     "tool-esptoolpy": {
       "type": "uploader",
-      "optional": true,
+      "optional": false,
       "owner": "tasmota",
       "version": "https://github.com/tasmota/esptool/releases/download/v4.8.9/esptool.zip"
     },

--- a/platform.json
+++ b/platform.json
@@ -79,7 +79,7 @@
     "tl-install": {
       "optional": false,
       "owner": "pioarduino",
-      "version": "https://github.com/pioarduino/esp_install/releases/download/v3.0.0/esp_install-v3.0.0.zip"
+      "version": "https://github.com/pioarduino/esp_install/releases/download/v5.0.0/esp_install-v5.0.0.zip"
     },
     "tool-dfuutil-arduino": {
       "type": "uploader",

--- a/platform.py
+++ b/platform.py
@@ -49,7 +49,9 @@ IDF_TOOLS_CMD = (
 )
 
 tl_flag = bool(os.path.exists(IDF_TOOLS))
-if (tl_flag and bool(os.path.exists(TOOLS_JSON_PATH))):
+json_flag = bool(os.path.exists(TOOLS_JSON_PATH))
+print("tl flag, json flag:" tl_flag, json_flag)
+if tl_flag and json_flag:
     rc = subprocess.call(IDF_TOOLS_CMD)
     if rc != 0:
         sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")
@@ -57,6 +59,7 @@ if (tl_flag and bool(os.path.exists(TOOLS_JSON_PATH))):
         tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
         shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
         pm.install(tl_path)
+        print("******* tl flag, json flag:" tl_flag, json_flag)
         os.remove(TOOLS_JSON_PATH)
 
 

--- a/platform.py
+++ b/platform.py
@@ -36,7 +36,7 @@ python_exe = get_pythonexe_path()
 pm = ToolPackageManager()
 
 TOOL = "tool-openocd-esp32"
-TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".platformio", ".install")
+export IDF_TOOLS_PATH = os.path.join(os.path.expanduser("~"), ".platformio", ".install")
 IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
 TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "tools.json")
 IDF_TOOLS_CMD = (

--- a/platform.py
+++ b/platform.py
@@ -28,6 +28,31 @@ IS_WINDOWS = sys.platform.startswith("win")
 if IS_WINDOWS:
     os.environ["PLATFORMIO_SYSTEM_TYPE"] = "windows_amd64"
 
+python_exe = get_pythonexe_path()
+pm = ToolPackageManager()
+
+IDF_TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".platformio", ".install")
+IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
+IDF_TOOLS_CMD = (
+    python_exe,
+    IDF_TOOLS,
+    "install",
+    "--tools-json",
+    tools_json_path
+)
+
+# IDF Install is needed only one time
+tl_flag = bool(os.path.exists(IDF_TOOLS))
+if (tl_flag and not bool(os.path.exists(join(IDF_TOOLS_PATH_DEFAULT, "tools")))):
+    rc = subprocess.call(IDF_TOOLS_CMD)
+    if rc != 0:
+        sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")
+    else:
+        shutil.copytree(join(IDF_TOOLS_PATH_DEFAULT, "tools", "tool-packages"), join(IDF_TOOLS_PATH_DEFAULT, "tools"), symlinks=False, ignore=None, ignore_dangling_symlinks=False, dirs_exist_ok=True)
+        for p in ("tool-openocd-esp32"):
+            tl_path = "file://" + join(IDF_TOOLS_PATH_DEFAULT, "tools", p)
+            pm.install(tl_path)
+
 
 class Espressif32Platform(PlatformBase):
     def configure_default_packages(self, variables, targets):

--- a/platform.py
+++ b/platform.py
@@ -37,6 +37,7 @@ pm = ToolPackageManager()
 
 TOOL = "tool-openocd-esp32"
 export IDF_TOOLS_PATH=~/.platformio/.install
+TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".platformio", ".install")
 IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
 TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "tools.json")
 IDF_TOOLS_CMD = (

--- a/platform.py
+++ b/platform.py
@@ -36,7 +36,7 @@ python_exe = get_pythonexe_path()
 pm = ToolPackageManager()
 
 TOOL = "tool-openocd-esp32"
-TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".espressif")
+TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".platformio")
 IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
 TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "tools.json")
 TOOLS_PACK_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "package.json")

--- a/platform.py
+++ b/platform.py
@@ -49,7 +49,7 @@ IDF_TOOLS_CMD = (
 )
 
 tl_flag = bool(os.path.exists(IDF_TOOLS))
-if (tl_flag and bool(os.path.exist(TOOLS_JSON_PATH))):
+if (tl_flag and bool(os.path.exists(TOOLS_JSON_PATH))):
     rc = subprocess.call(IDF_TOOLS_CMD)
     if rc != 0:
         sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")

--- a/platform.py
+++ b/platform.py
@@ -38,7 +38,7 @@ pm = ToolPackageManager()
 TOOL = "tool-openocd-esp32"
 TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".platformio", ".install")
 IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
-TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL)
+TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "tools.json")
 IDF_TOOLS_CMD = (
     python_exe,
     IDF_TOOLS,
@@ -48,14 +48,14 @@ IDF_TOOLS_CMD = (
 )
 
 tl_flag = bool(os.path.exists(IDF_TOOLS))
-if (tl_flag and bool(os.path.isfile(join(TOOLS_JSON_PATH, "tools.json")))):
+if (tl_flag and bool(os.path.isfile(join(TOOLS_JSON_PATH)))):
     rc = subprocess.call(IDF_TOOLS_CMD)
     if rc != 0:
         sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")
     else:
         tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
         pm.install(tl_path)
-        os.remove(join(TOOLS_JSON_PATH, "tools.json"))
+        os.remove(join(TOOLS_JSON_PATH))
 
 
 class Espressif32Platform(PlatformBase):

--- a/platform.py
+++ b/platform.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import urllib
-import sys
 import json
-import re
+import os
+import subprocess
+import sys
+import shutil
+from os.path import isfile, join
 
 from platformio.public import PlatformBase, to_unix_path
+from platformio.proc import get_pythonexe_path
+from platformio.project.config import ProjectConfig
+from platformio.package.manager.tool import ToolPackageManager
 
 
 IS_WINDOWS = sys.platform.startswith("win")
@@ -31,27 +35,27 @@ if IS_WINDOWS:
 python_exe = get_pythonexe_path()
 pm = ToolPackageManager()
 
-IDF_TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".platformio", ".install")
+TOOL = "tool-openocd-esp32"
+TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".platformio", ".install")
 IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
+TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL)
 IDF_TOOLS_CMD = (
     python_exe,
     IDF_TOOLS,
     "install",
     "--tools-json",
-    tools_json_path
+    TOOLS_JSON_PATH
 )
 
-# IDF Install is needed only one time
 tl_flag = bool(os.path.exists(IDF_TOOLS))
-if (tl_flag and not bool(os.path.exists(join(IDF_TOOLS_PATH_DEFAULT, "tools")))):
+if (tl_flag and bool(os.path.isfile(join(TOOLS_JSON_PATH, "tools.json")))):
     rc = subprocess.call(IDF_TOOLS_CMD)
     if rc != 0:
         sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")
     else:
-        shutil.copytree(join(IDF_TOOLS_PATH_DEFAULT, "tools", "tool-packages"), join(IDF_TOOLS_PATH_DEFAULT, "tools"), symlinks=False, ignore=None, ignore_dangling_symlinks=False, dirs_exist_ok=True)
-        for p in ("tool-openocd-esp32"):
-            tl_path = "file://" + join(IDF_TOOLS_PATH_DEFAULT, "tools", p)
-            pm.install(tl_path)
+        tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
+        pm.install(tl_path)
+        os.remove(join(TOOLS_JSON_PATH, "tools.json"))
 
 
 class Espressif32Platform(PlatformBase):

--- a/platform.py
+++ b/platform.py
@@ -118,6 +118,9 @@ class Espressif32Platform(PlatformBase):
         # bundled GDB. Instead, it's distributed as separate packages for Xtensa
         # and RISC-V targets.
         print("***** targets:", targets)
+        print("==== Dumping Environment Variables ====")
+        print(env.Dump())
+        print("=======================================")
         if "debug" in targets:
             for gdb_package in ("tool-xtensa-esp-elf-gdb", "tool-riscv32-esp-elf-gdb"):
                 self.packages[gdb_package]["optional"] = False

--- a/platform.py
+++ b/platform.py
@@ -34,32 +34,33 @@ if IS_WINDOWS:
 python_exe = get_pythonexe_path()
 pm = ToolPackageManager()
 
-TOOL = "tool-openocd-esp32"
-TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".platformio")
-IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
-TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "tools.json")
-TOOLS_PACK_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "package.json")
-IDF_TOOLS_CMD = (
-    python_exe,
-    IDF_TOOLS,
-    "--quiet",
-    "--non-interactive",
-    "--tools-json",
-    TOOLS_JSON_PATH,
-    "install"
-)
+def install_tool(TOOL):
+    TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".platformio")
+    IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
+    TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "tools.json")
+    TOOLS_PACK_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "package.json")
+    IDF_TOOLS_CMD = (
+        python_exe,
+        IDF_TOOLS,
+        "--quiet",
+        "--non-interactive",
+        "--tools-json",
+        TOOLS_JSON_PATH,
+        "install"
+    )
 
-tl_flag = bool(os.path.exists(IDF_TOOLS))
-json_flag = bool(os.path.exists(TOOLS_JSON_PATH))
-if tl_flag and json_flag:
-    rc = subprocess.call(IDF_TOOLS_CMD)
-    if rc != 0:
-        sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")
-    else:
-        tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
-        shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
-        pm.install(tl_path)
+    tl_flag = bool(os.path.exists(IDF_TOOLS))
+    json_flag = bool(os.path.exists(TOOLS_JSON_PATH))
+    if tl_flag and json_flag:
+        rc = subprocess.call(IDF_TOOLS_CMD)
+        if rc != 0:
+            sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")
+        else:
+            tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
+            shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
+            pm.install(tl_path)
 
+install_tool("tool-openocd-esp32")
 
 class Espressif32Platform(PlatformBase):
     def configure_default_packages(self, variables, targets):

--- a/platform.py
+++ b/platform.py
@@ -51,7 +51,7 @@ IDF_TOOLS_CMD = (
 tl_flag = bool(os.path.exists(IDF_TOOLS))
 json_flag = bool(os.path.exists(TOOLS_JSON_PATH))
 print("tl flag, json flag:", tl_flag, json_flag)
-if tl_flag and json_flag:
+if tl_flag == True and json_flag == True:
     rc = subprocess.call(IDF_TOOLS_CMD)
     if rc != 0:
         sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")

--- a/platform.py
+++ b/platform.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import os
 import subprocess
 import sys
 import shutil
-from os.path import isfile, join
+from os.path import join
 
 from platformio.public import PlatformBase, to_unix_path
 from platformio.proc import get_pythonexe_path

--- a/platform.py
+++ b/platform.py
@@ -57,7 +57,6 @@ if tl_flag and json_flag:
     else:
         tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
         shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
-        print("Installing:", join(TOOLS_PATH_DEFAULT, "tools", TOOL))
         pm.install(tl_path)
 
 

--- a/platform.py
+++ b/platform.py
@@ -49,7 +49,7 @@ IDF_TOOLS_CMD = (
 )
 
 tl_flag = bool(os.path.exists(IDF_TOOLS))
-if (tl_flag and bool(os.path.isfile(join(TOOLS_JSON_PATH)))):
+if (tl_flag and bool(os.path.exist(TOOLS_JSON_PATH))):
     rc = subprocess.call(IDF_TOOLS_CMD)
     if rc != 0:
         sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")

--- a/platform.py
+++ b/platform.py
@@ -51,7 +51,7 @@ IDF_TOOLS_CMD = (
 tl_flag = bool(os.path.exists(IDF_TOOLS))
 json_flag = bool(os.path.exists(TOOLS_JSON_PATH))
 print("tl flag, json flag:", tl_flag, json_flag)
-if tl_flag == True and json_flag == True:
+if tl_flag and json_flag:
     rc = subprocess.call(IDF_TOOLS_CMD)
     if rc != 0:
         sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")
@@ -60,7 +60,7 @@ if tl_flag == True and json_flag == True:
         shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
         pm.install(tl_path)
         print("******* tl flag, json flag:", tl_flag, json_flag)
-        os.remove(TOOLS_JSON_PATH)
+        #os.remove(TOOLS_JSON_PATH)
 
 
 class Espressif32Platform(PlatformBase):

--- a/platform.py
+++ b/platform.py
@@ -50,7 +50,6 @@ IDF_TOOLS_CMD = (
 
 tl_flag = bool(os.path.exists(IDF_TOOLS))
 json_flag = bool(os.path.exists(TOOLS_JSON_PATH))
-print("tl flag, json flag:", tl_flag, json_flag)
 if tl_flag and json_flag:
     rc = subprocess.call(IDF_TOOLS_CMD)
     if rc != 0:
@@ -58,9 +57,8 @@ if tl_flag and json_flag:
     else:
         tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
         shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
+        print("Installing:", join(TOOLS_PATH_DEFAULT, "tools", TOOL))
         pm.install(tl_path)
-        print("******* tl flag, json flag:", tl_flag, json_flag)
-        #os.remove(TOOLS_JSON_PATH)
 
 
 class Espressif32Platform(PlatformBase):

--- a/platform.py
+++ b/platform.py
@@ -95,7 +95,7 @@ class Espressif32Platform(PlatformBase):
                 self.packages["tool-mklittlefs"]["optional"] = False
             elif filesystem == "fatfs":
                 self.packages["tool-mkfatfs"]["optional"] = False
-        if variables.get("upload_protocol"):
+        if variables.get("upload_protocol") or "debug" in targets:
             self.packages["tool-openocd-esp32"]["optional"] = False
         if os.path.isdir("ulp"):
             self.packages["toolchain-esp32ulp"]["optional"] = False
@@ -115,12 +115,9 @@ class Espressif32Platform(PlatformBase):
         # Starting from v12, Espressif's toolchains are shipped without
         # bundled GDB. Instead, it's distributed as separate packages for Xtensa
         # and RISC-V targets.
-        for gdb_package in ("tool-xtensa-esp-elf-gdb", "tool-riscv32-esp-elf-gdb"):
-            self.packages[gdb_package]["optional"] = False
-            # if IS_WINDOWS:
-                # Note: On Windows GDB v12 is not able to
-                # launch a GDB server in pipe mode while v11 works fine
-                # self.packages[gdb_package]["version"] = "~11.2.0"
+        if "debug" in targets:
+            for gdb_package in ("tool-xtensa-esp-elf-gdb", "tool-riscv32-esp-elf-gdb"):
+                self.packages[gdb_package]["optional"] = False
 
         # Common packages for IDF and mixed Arduino+IDF projects
         if "espidf" in frameworks:

--- a/platform.py
+++ b/platform.py
@@ -36,8 +36,7 @@ python_exe = get_pythonexe_path()
 pm = ToolPackageManager()
 
 TOOL = "tool-openocd-esp32"
-export IDF_TOOLS_PATH=~/.platformio/.install
-TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".platformio", ".install")
+TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".espressif", "dist")
 IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
 TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "tools.json")
 IDF_TOOLS_CMD = (

--- a/platform.py
+++ b/platform.py
@@ -44,7 +44,7 @@ IDF_TOOLS_CMD = (
     python_exe,
     IDF_TOOLS,
     "--quiet",
-    "--non-interactive"
+    "--non-interactive",
     "--tools-json",
     TOOLS_JSON_PATH,
     "install"

--- a/platform.py
+++ b/platform.py
@@ -96,9 +96,6 @@ class Espressif32Platform(PlatformBase):
                 self.packages["tool-mklittlefs"]["optional"] = False
             elif filesystem == "fatfs":
                 self.packages["tool-mkfatfs"]["optional"] = False
-        if variables.get("upload_protocol") or "debug" in targets:
-            install_tool("tool-openocd-esp32")
-            self.packages["tool-openocd-esp32"]["optional"] = False
         if os.path.isdir("ulp"):
             self.packages["toolchain-esp32ulp"]["optional"] = False
 
@@ -117,13 +114,11 @@ class Espressif32Platform(PlatformBase):
         # Starting from v12, Espressif's toolchains are shipped without
         # bundled GDB. Instead, it's distributed as separate packages for Xtensa
         # and RISC-V targets.
-        print("***** targets:", targets)
-        print("==== Dumping Environment Variables ====")
-        print(env.Dump())
-        print("=======================================")
-        if "debug" in targets:
+        if (variables.get("build_type") or "debug" in "".join(targets)) or variables.get("upload_protocol"):
             for gdb_package in ("tool-xtensa-esp-elf-gdb", "tool-riscv32-esp-elf-gdb"):
                 self.packages[gdb_package]["optional"] = False
+            install_tool("tool-openocd-esp32")
+            self.packages["tool-openocd-esp32"]["optional"] = False
 
         # Common packages for IDF and mixed Arduino+IDF projects
         if "espidf" in frameworks:

--- a/platform.py
+++ b/platform.py
@@ -70,6 +70,8 @@ class Espressif32Platform(PlatformBase):
         board_sdkconfig = variables.get("board_espidf.custom_sdkconfig", board_config.get("espidf.custom_sdkconfig", ""))
         frameworks = variables.get("pioframework", [])
 
+        # Installer only needed for setup, deactivate
+        self.packages["tl-install"]["optional"] = True
         # Installed not from pio registry, deactivate until needed
         self.packages["tool-openocd-esp32"]["optional"] = True
 

--- a/platform.py
+++ b/platform.py
@@ -59,8 +59,8 @@ def install_tool(TOOL):
             tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
             shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
             pm.install(tl_path)
+    return
 
-install_tool("tool-openocd-esp32")
 
 class Espressif32Platform(PlatformBase):
     def configure_default_packages(self, variables, targets):
@@ -97,6 +97,7 @@ class Espressif32Platform(PlatformBase):
             elif filesystem == "fatfs":
                 self.packages["tool-mkfatfs"]["optional"] = False
         if variables.get("upload_protocol") or "debug" in targets:
+            install_tool("tool-openocd-esp32")
             self.packages["tool-openocd-esp32"]["optional"] = False
         if os.path.isdir("ulp"):
             self.packages["toolchain-esp32ulp"]["optional"] = False

--- a/platform.py
+++ b/platform.py
@@ -117,6 +117,7 @@ class Espressif32Platform(PlatformBase):
         # Starting from v12, Espressif's toolchains are shipped without
         # bundled GDB. Instead, it's distributed as separate packages for Xtensa
         # and RISC-V targets.
+        print("***** targets:", targets)
         if "debug" in targets:
             for gdb_package in ("tool-xtensa-esp-elf-gdb", "tool-riscv32-esp-elf-gdb"):
                 self.packages[gdb_package]["optional"] = False

--- a/platform.py
+++ b/platform.py
@@ -39,6 +39,7 @@ TOOL = "tool-openocd-esp32"
 TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".espressif")
 IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
 TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "tools.json")
+TOOLS_PACK_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "package.json")
 IDF_TOOLS_CMD = (
     python_exe,
     IDF_TOOLS,
@@ -54,6 +55,7 @@ if (tl_flag and bool(os.path.isfile(join(TOOLS_JSON_PATH)))):
         sys.stderr.write("Error: Couldn't execute 'idf_tools.py install'\n")
     else:
         tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
+        shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
         pm.install(tl_path)
         os.remove(join(TOOLS_JSON_PATH))
 

--- a/platform.py
+++ b/platform.py
@@ -43,11 +43,11 @@ TOOLS_PACK_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "p
 IDF_TOOLS_CMD = (
     python_exe,
     IDF_TOOLS,
-    "--tools-json",
-    TOOLS_JSON_PATH,
-    "install",
     "--quiet",
     "--non-interactive"
+    "--tools-json",
+    TOOLS_JSON_PATH,
+    "install"
 )
 
 tl_flag = bool(os.path.exists(IDF_TOOLS))

--- a/platform.py
+++ b/platform.py
@@ -45,7 +45,9 @@ IDF_TOOLS_CMD = (
     IDF_TOOLS,
     "--tools-json",
     TOOLS_JSON_PATH,
-    "install"
+    "install",
+    "--quiet",
+    "--non-interactive"
 )
 
 tl_flag = bool(os.path.exists(IDF_TOOLS))

--- a/platform.py
+++ b/platform.py
@@ -36,7 +36,7 @@ python_exe = get_pythonexe_path()
 pm = ToolPackageManager()
 
 TOOL = "tool-openocd-esp32"
-TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".espressif", "dist")
+TOOLS_PATH_DEFAULT = os.path.join(os.path.expanduser("~"), ".espressif")
 IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
 TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "tools.json")
 IDF_TOOLS_CMD = (

--- a/platform.py
+++ b/platform.py
@@ -50,7 +50,7 @@ IDF_TOOLS_CMD = (
 
 tl_flag = bool(os.path.exists(IDF_TOOLS))
 json_flag = bool(os.path.exists(TOOLS_JSON_PATH))
-print("tl flag, json flag:" tl_flag, json_flag)
+print("tl flag, json flag:", tl_flag, json_flag)
 if tl_flag and json_flag:
     rc = subprocess.call(IDF_TOOLS_CMD)
     if rc != 0:
@@ -59,7 +59,7 @@ if tl_flag and json_flag:
         tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
         shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
         pm.install(tl_path)
-        print("******* tl flag, json flag:" tl_flag, json_flag)
+        print("******* tl flag, json flag:", tl_flag, json_flag)
         os.remove(TOOLS_JSON_PATH)
 
 

--- a/platform.py
+++ b/platform.py
@@ -36,7 +36,7 @@ python_exe = get_pythonexe_path()
 pm = ToolPackageManager()
 
 TOOL = "tool-openocd-esp32"
-export IDF_TOOLS_PATH = os.path.join(os.path.expanduser("~"), ".platformio", ".install")
+export IDF_TOOLS_PATH=~/.platformio/.install
 IDF_TOOLS = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), "tl-install", "tools", "idf_tools.py")
 TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "packages_dir"), TOOL, "tools.json")
 IDF_TOOLS_CMD = (

--- a/platform.py
+++ b/platform.py
@@ -70,6 +70,9 @@ class Espressif32Platform(PlatformBase):
         board_sdkconfig = variables.get("board_espidf.custom_sdkconfig", board_config.get("espidf.custom_sdkconfig", ""))
         frameworks = variables.get("pioframework", [])
 
+        # Installed not from pio registry, deactivate until needed
+        self.packages["tool-openocd-esp32"]["optional"] = True
+
         if "arduino" in frameworks and variables.get("custom_sdkconfig") is None and len(str(board_sdkconfig)) < 3:
             self.packages["framework-arduinoespressif32"]["optional"] = False
 

--- a/platform.py
+++ b/platform.py
@@ -57,7 +57,7 @@ if (tl_flag and bool(os.path.isfile(join(TOOLS_JSON_PATH)))):
         tl_path = "file://" + join(TOOLS_PATH_DEFAULT, "tools", TOOL)
         shutil.copyfile(TOOLS_PACK_PATH, join(TOOLS_PATH_DEFAULT, "tools", TOOL, "package.json"))
         pm.install(tl_path)
-        os.remove(join(TOOLS_JSON_PATH))
+        os.remove(TOOLS_JSON_PATH)
 
 
 class Espressif32Platform(PlatformBase):

--- a/platform.py
+++ b/platform.py
@@ -42,9 +42,9 @@ TOOLS_JSON_PATH = os.path.join(ProjectConfig.get_instance().get("platformio", "p
 IDF_TOOLS_CMD = (
     python_exe,
     IDF_TOOLS,
-    "install",
     "--tools-json",
-    TOOLS_JSON_PATH
+    TOOLS_JSON_PATH,
+    "install"
 )
 
 tl_flag = bool(os.path.exists(IDF_TOOLS))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new installation package to enhance tool setup.
  - Introduced automatic installation support for a key debugging tool.
- **Bug Fixes**
  - Updated package configurations to ensure essential tools are installed and activated as needed.
- **Chores**
  - Refined package activation rules for improved management of debugging and upload tools.
  - Set explicit build type to debug for a specific development environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->