### PR TITLE
Remove support for frameworks solo1 / ITEAD

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -25,22 +25,12 @@ from platformio.util import get_serial_ports
 env = DefaultEnvironment()
 platform = env.PioPlatform()
 config = env.GetProjectConfig()
-extra_flags = ''.join([element.replace("-D", " ") for element in env.BoardConfig().get("build.extra_flags", "")])
-build_flags = ''.join([element.replace("-D", " ") for element in env.GetProjectOption("build_flags")])
-flag_custom_sdkonfig = False
-if config.has_option("env:"+env["PIOENV"], "custom_sdkconfig"):
-    flag_custom_sdkonfig = True
 
 #
 # Helpers
 #
 
-if "CORE32SOLO1" in extra_flags or "FRAMEWORK_ARDUINO_SOLO1" in build_flags and flag_custom_sdkonfig is False:
-    FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-solo1")
-elif "CORE32ITEAD" in extra_flags or "FRAMEWORK_ARDUINO_ITEAD" in build_flags and flag_custom_sdkonfig is False:
-    FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-ITEAD")
-else:
-    FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
+FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
 
 def BeforeUpload(target, source, env):
     upload_options = {}

--- a/platform.json
+++ b/platform.json
@@ -35,18 +35,6 @@
       "owner": "tasmota",
       "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3602/framework-arduinoespressif32-all-release_v5.3-138e9bb2.zip"
     },
-    "framework-arduino-solo1": {
-      "type": "framework",
-      "optional": true,
-      "owner": "tasmota",
-      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3558/framework-arduinoespressif32-solo1-release_v5.3-a9e96157.zip"
-    },
-    "framework-arduino-ITEAD": {
-      "type": "framework",
-      "optional": true,
-      "owner": "tasmota",
-      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3559/framework-arduinoespressif32-ITEAD-esp32-release_v5.3-a9e96157.zip"
-    },
     "framework-espidf": {
       "type": "framework",
       "optional": true,

--- a/platform.json
+++ b/platform.json
@@ -33,7 +33,7 @@
       "type": "framework",
       "optional": true,
       "owner": "tasmota",
-      "version": "https://github.com/tasmota/arduino-esp32/releases/download/v3.1.3.250504/framework-arduinoespressif32.zip"
+      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3610/framework-arduinoespressif32-all-release_v5.3-58fe5163.zip"
     },
     "framework-espidf": {
       "type": "framework",

--- a/platform.json
+++ b/platform.json
@@ -33,7 +33,7 @@
       "type": "framework",
       "optional": true,
       "owner": "tasmota",
-      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3602/framework-arduinoespressif32-all-release_v5.3-138e9bb2.zip"
+      "version": "https://github.com/tasmota/arduino-esp32/releases/download/v3.1.3.250504/framework-arduinoespressif32.zip"
     },
     "framework-espidf": {
       "type": "framework",
@@ -79,8 +79,8 @@
     "tool-esptoolpy": {
       "type": "uploader",
       "optional": false,
-      "owner": "Jason2866",
-      "version": "https://github.com/Jason2866/esptool/releases/download/v4.8.10/esptool.zip"
+      "owner": "tasmota",
+      "version": "https://github.com/tasmota/esptool/releases/download/v4.8.10/esptool.zip"
     },
     "tl-install": {
       "type": "tool",

--- a/platform.py
+++ b/platform.py
@@ -43,9 +43,6 @@ class Espressif32Platform(PlatformBase):
         board_config = self.board_config(variables.get("board"))
         mcu = variables.get("board_build.mcu", board_config.get("build.mcu", "esp32"))
         board_sdkconfig = variables.get("board_espidf.custom_sdkconfig", board_config.get("espidf.custom_sdkconfig", ""))
-        core_variant_board = ''.join(variables.get("board_build.extra_flags", board_config.get("build.extra_flags", "")))
-        core_variant_board = core_variant_board.replace("-D", " ")
-        core_variant_build = (''.join(variables.get("build_flags", []))).replace("-D", " ")
         frameworks = variables.get("pioframework", [])
 
         def install_tool(TOOL, retry_count=0):
@@ -120,12 +117,7 @@ class Espressif32Platform(PlatformBase):
             self.packages["tl-install"]["optional"] = True
 
         if "arduino" in frameworks and variables.get("custom_sdkconfig") is None and len(str(board_sdkconfig)) < 3:
-            if "CORE32SOLO1" in core_variant_board or "FRAMEWORK_ARDUINO_SOLO1" in core_variant_build:
-                self.packages["framework-arduino-solo1"]["optional"] = False
-            elif "CORE32ITEAD" in core_variant_board or "FRAMEWORK_ARDUINO_ITEAD" in core_variant_build:
-                self.packages["framework-arduino-ITEAD"]["optional"] = False
-            else:
-                self.packages["framework-arduinoespressif32"]["optional"] = False
+            self.packages["framework-arduinoespressif32"]["optional"] = False
 
         if variables.get("custom_sdkconfig") is not None or len(str(board_sdkconfig)) > 3:
             frameworks.append("espidf")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified Arduino framework selection by always using the default "framework-arduinoespressif32" package.
  - Removed support for optional Arduino framework variants ("framework-arduino-solo1" and "framework-arduino-ITEAD").
  - Updated package sources and versions for the Arduino framework and uploader tool.
  - Streamlined internal logic for framework configuration and package selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->