### PR TITLE
esptool v5.0.0-dev 

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -103,6 +103,7 @@ def install_python_deps():
         "wheel": ">=0.35.1",
         "rich-click": ">=1.8.6",
         "zopfli": ">=0.2.2",
+        "intelhex": ">=2.3.0",
         "esp-idf-size": ">=1.6.1"
     }
 
@@ -269,9 +270,4 @@ if flag_custom_sdkconfig == True and flag_any_custom_sdkconfig == False:
 if "arduino" in env.subst("$PIOFRAMEWORK") and "espidf" not in env.subst("$PIOFRAMEWORK") and env.subst("$ARDUINO_LIB_COMPILE_FLAG") in ("Inactive", "True"):
     if IS_WINDOWS:
         env.AddBuildMiddleware(shorthen_includes)
-    if os.path.exists(join(platform.get_package_dir(
-            "framework-arduinoespressif32"), "tools", "platformio-build.py")):
-        PIO_BUILD = "platformio-build.py"
-    else:
-        PIO_BUILD = "pioarduino-build.py"
-    SConscript(join(platform.get_package_dir("framework-arduinoespressif32"), "tools", PIO_BUILD))
+    SConscript(join(platform.get_package_dir("framework-arduinoespressif32"), "tools", "pioarduino-build.py"))

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -89,6 +89,7 @@ def install_standard_python_deps():
         "wheel": ">=0.35.1",
         "rich-click": ">=1.8.6",
         "PyYAML": ">=6.0.2",
+        "intelhex": ">=2.3.0",
         "esp-idf-size": ">=1.6.1"
     }
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -270,7 +270,7 @@ env.Replace(
         "--chip", mcu,
         "--port", '"$UPLOAD_PORT"'
     ],
-    ERASECMD='"$PYTHONEXE" "$OBJCOPY" $ERASEFLAGS erase_flash',
+    ERASECMD='"$PYTHONEXE" "$OBJCOPY" $ERASEFLAGS erase-flash',
 
     MKFSTOOL="mk%s" % filesystem,
 
@@ -311,9 +311,9 @@ env.Append(
             action=env.VerboseAction(" ".join([
                 '"$PYTHONEXE" "$OBJCOPY"',
                 "--chip", mcu, "elf2image",
-                "--flash_mode", "${__get_board_flash_mode(__env__)}",
-                "--flash_freq", "${__get_board_f_image(__env__)}",
-                "--flash_size", board.get("upload.flash_size", "4MB"),
+                "--flash-mode", "${__get_board_flash_mode(__env__)}",
+                "--flash-freq", "${__get_board_f_image(__env__)}",
+                "--flash-size", board.get("upload.flash_size", "4MB"),
                 "-o", "$TARGET", "$SOURCES"
             ]), "Building $TARGET"),
             suffix=".bin"
@@ -467,12 +467,12 @@ elif upload_protocol == "esptool":
             "--chip", mcu,
             "--port", '"$UPLOAD_PORT"',
             "--baud", "$UPLOAD_SPEED",
-            "--before", board.get("upload.before_reset", "default_reset"),
-            "--after", board.get("upload.after_reset", "hard_reset"),
-            "write_flash", "-z",
-            "--flash_mode", "${__get_board_flash_mode(__env__)}",
-            "--flash_freq", "${__get_board_f_image(__env__)}",
-            "--flash_size", "detect"
+            "--before", board.get("upload.before_reset", "default-reset"),
+            "--after", board.get("upload.after_reset", "hard-reset"),
+            "write-flash", "-z",
+            "--flash-mode", "${__get_board_flash_mode(__env__)}",
+            "--flash-freq", "${__get_board_f_image(__env__)}",
+            "--flash-size", "detect"
         ],
         UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS $ESP32_APP_OFFSET $SOURCE'
     )
@@ -485,12 +485,12 @@ elif upload_protocol == "esptool":
                 "--chip", mcu,
                 "--port", '"$UPLOAD_PORT"',
                 "--baud", "$UPLOAD_SPEED",
-                "--before", board.get("upload.before_reset", "default_reset"),
-                "--after", board.get("upload.after_reset", "hard_reset"),
-                "write_flash", "-z",
-                "--flash_mode", "${__get_board_flash_mode(__env__)}",
-                "--flash_freq", "${__get_board_f_image(__env__)}",
-                "--flash_size", "detect",
+                "--before", board.get("upload.before_reset", "default-reset"),
+                "--after", board.get("upload.after_reset", "hard-reset"),
+                "write-flash", "-z",
+                "--flash-mode", "${__get_board_flash_mode(__env__)}",
+                "--flash-freq", "${__get_board_f_image(__env__)}",
+                "--flash-size", "detect",
                 "$FS_START"
             ],
             UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS $SOURCE',

--- a/platform.json
+++ b/platform.json
@@ -33,7 +33,7 @@
       "type": "framework",
       "optional": true,
       "owner": "tasmota",
-      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3691/framework-arduinoespressif32-all-release_v5.3-1882a67c.zip"
+      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/3707/framework-arduinoespressif32-all-release_v5.3-a308dd1e.zip"
     },
     "framework-espidf": {
       "type": "framework",

--- a/platform.json
+++ b/platform.json
@@ -80,7 +80,7 @@
       "type": "uploader",
       "optional": false,
       "owner": "tasmota",
-      "version": "https://github.com/tasmota/esptool/releases/download/v4.8.11/esptool.zip"
+      "version": "https://github.com/Jason2866/esptool/releases/download/v5.0.0-dev/esptool.zip"
     },
     "tl-install": {
       "type": "tool",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated required Python dependencies to include "intelhex" (version 2.3.0 or higher) for Arduino and ESP-IDF environments.
  - Updated package version URLs for Arduino and esptool uploader in the platform configuration.
- **Style**
  - Standardized command-line flags for esptool operations, switching from underscores to hyphens for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->