### PR TITLE
use uv package manager to install python dependencies

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-15]
+        os: [ubuntu-latest, windows-latest, macos-15]
         example:
           - "examples/arduino-blink"
           - "examples/arduino-rmt-blink"

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-15]
+        os: [macos-15]
         example:
           - "examples/arduino-blink"
           - "examples/arduino-rmt-blink"

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1487,8 +1487,8 @@ def install_python_deps():
                 "uv", "pip", "list", "--python", python_exe_path, "--format=json"
             ])
             packages = json.loads(uv_output)
-        except:
-            print("Warning! Couldn't extract the list of installed Python packages.")
+        except (subprocess.CalledProcessError, json.JSONDecodeError, OSError) as e:
+            print(f"Warning! Couldn't extract the list of installed Python packages: {e}")
             return {}
         
         for p in packages:

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -56,68 +56,6 @@ map_file = os.path.join(env.subst("$PROJECT_DIR"), env.subst("$PROGNAME") + ".ma
 if os.path.exists(map_file):
     os.remove(map_file)
 
-def install_standard_python_deps():
-    def _get_installed_standard_pip_packages():
-        result = {}
-        packages = {}
-        pip_output = subprocess.check_output(
-            [
-                env.subst("$PYTHONEXE"),
-                "-m",
-                "pip",
-                "list",
-                "--format=json",
-                "--disable-pip-version-check",
-            ]
-        )
-        try:
-            packages = json.loads(pip_output)
-        except:
-            print("Warning! Couldn't extract the list of installed Python packages.")
-            return {}
-        for p in packages:
-            result[p["name"]] = pepver_to_semver(p["version"])
-
-        return result
-
-    deps = {
-        "wheel": ">=0.35.1",
-        "rich-click": ">=1.8.6",
-        "PyYAML": ">=6.0.2",
-        "intelhex": ">=2.3.0",
-        "rich": ">=14.0.0",
-        "esp-idf-size": ">=1.6.1"
-    }
-
-    installed_packages = _get_installed_standard_pip_packages()
-    packages_to_install = []
-    for package, spec in deps.items():
-        if package not in installed_packages:
-            packages_to_install.append(package)
-        else:
-            version_spec = semantic_version.Spec(spec)
-            if not version_spec.match(installed_packages[package]):
-                packages_to_install.append(package)
-
-    if packages_to_install:
-        env.Execute(
-            env.VerboseAction(
-                (
-                    '"$PYTHONEXE" -m pip install -U -q -q -q '
-                    + " ".join(
-                        [
-                            '"%s%s"' % (p, deps[p])
-                            for p in packages_to_install
-                        ]
-                    )
-                ),
-                "Installing standard Python dependencies",
-            )
-        )
-    return
-
-install_standard_python_deps()
-
 # Allow changes in folders of managed components
 os.environ["IDF_COMPONENT_OVERWRITE_MANAGED_COMPONENTS"] = "1"
 
@@ -1542,24 +1480,17 @@ def generate_mbedtls_bundle(sdk_config):
 
 
 def install_python_deps():
-    def _get_installed_pip_packages(python_exe_path):
+    def _get_installed_uv_packages(python_exe_path):
         result = {}
-        packages = {}
-        pip_output = subprocess.check_output(
-            [
-                python_exe_path,
-                "-m",
-                "pip",
-                "list",
-                "--format=json",
-                "--disable-pip-version-check",
-            ]
-        )
         try:
-            packages = json.loads(pip_output)
+            uv_output = subprocess.check_output([
+                "uv", "pip", "list", "--python", python_exe_path, "--format=json"
+            ])
+            packages = json.loads(uv_output)
         except:
             print("Warning! Couldn't extract the list of installed Python packages.")
             return {}
+        
         for p in packages:
             result[p["name"]] = pepver_to_semver(p["version"])
 
@@ -1570,7 +1501,7 @@ def install_python_deps():
         return
 
     deps = {
-        "wheel": ">=0.35.1",
+        "uv": ">=0.1.0",
         # https://github.com/platformio/platformio-core/issues/4614
         "urllib3": "<2",
         # https://github.com/platformio/platform-espressif32/issues/635
@@ -1584,7 +1515,7 @@ def install_python_deps():
         deps["chardet"] = ">=3.0.2,<4"
 
     python_exe_path = get_python_exe()
-    installed_packages = _get_installed_pip_packages(python_exe_path)
+    installed_packages = _get_installed_uv_packages(python_exe_path)
     packages_to_install = []
     for package, spec in deps.items():
         if package not in installed_packages:
@@ -1595,21 +1526,22 @@ def install_python_deps():
                 packages_to_install.append(package)
 
     if packages_to_install:
+        packages_str = " ".join(['"%s%s"' % (p, deps[p]) for p in packages_to_install])
+        
+        # Use uv to install packages in the specific Python environment
         env.Execute(
             env.VerboseAction(
-                (
-                    '"%s" -m pip install -U -q -q -q ' % python_exe_path
-                    + " ".join(['"%s%s"' % (p, deps[p]) for p in packages_to_install])
-                ),
-                "Installing ESP-IDF's Python dependencies",
+                f'uv pip install --python "{python_exe_path}" {packages_str}',
+                "Installing ESP-IDF's Python dependencies with uv",
             )
         )
 
     if IS_WINDOWS and "windows-curses" not in installed_packages:
+        # Install windows-curses in the IDF Python environment
         env.Execute(
             env.VerboseAction(
-                '"%s" -m pip install -q -q -q windows-curses' % python_exe_path,
-                "Installing windows-curses package",
+                f'uv pip install --python "{python_exe_path}" windows-curses',
+                "Installing windows-curses package with uv",
             )
         )
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -176,7 +176,7 @@ def install_python_deps():
     return True
 
 
-def _install_esptool(env):
+def install_esptool(env):
     """Install esptool from package folder "tool-esptoolpy" using uv package manager"""
     try:
         subprocess.check_call([env.subst("$PYTHONEXE"), "-c", "import esptool"], 
@@ -202,7 +202,7 @@ def _install_esptool(env):
 
 
 install_python_deps()
-_install_esptool(env)
+install_esptool(env)
 
 
 def _install_esptool(env):

--- a/builder/main.py
+++ b/builder/main.py
@@ -205,29 +205,6 @@ install_python_deps()
 install_esptool(env)
 
 
-def _install_esptool(env):
-    """Install esptool from package folder if not already installed"""
-    try:
-        subprocess.check_call([env.subst("$PYTHONEXE"), "-c", "import esptool"], 
-                              stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        return True
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        pass
-    
-    esptool_repo_path = env.subst(platform.get_package_dir("tool-esptoolpy") or "")
-    if esptool_repo_path and os.path.isdir(esptool_repo_path):
-        try:
-            subprocess.check_call([
-                env.subst("$PYTHONEXE"), "-m", "pip", "install", "-qqq", "-e", esptool_repo_path
-            ])
-            return True
-        except subprocess.CalledProcessError as e:
-            print(f"Warning: Failed to install esptool: {e}")
-            return False
-    
-    return False
-
-
 def BeforeUpload(target, source, env):
     """
     Prepare the environment before uploading firmware.

--- a/builder/main.py
+++ b/builder/main.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import locale
+import json
 import os
 import re
+import semantic_version
 import shlex
 import subprocess
 import sys
@@ -30,7 +32,9 @@ from SCons.Script import (
 )
 
 from platformio.project.helpers import get_project_dir
+from platformio.package.version import pepver_to_semver
 from platformio.util import get_serial_ports
+
 
 # Initialize environment and configuration
 env = DefaultEnvironment()
@@ -40,6 +44,165 @@ terminal_cp = locale.getpreferredencoding().lower()
 
 # Framework directory path
 FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
+
+python_deps = {
+    "uv": ">=0.1.0",
+    "pyyaml": ">=6.0.2",
+    "rich-click": ">=1.8.6",
+    "zopfli": ">=0.2.2",
+    "intelhex": ">=2.3.0",
+    "rich": ">=14.0.0",
+    "esp-idf-size": ">=1.6.1"
+}
+
+
+def get_packages_to_install(deps, installed_packages):
+    """Generator for Python packages to install"""
+    for package, spec in deps.items():
+        if package not in installed_packages:
+            yield package
+        else:
+            version_spec = semantic_version.Spec(spec)
+            if not version_spec.match(installed_packages[package]):
+                yield package
+
+
+def install_python_deps():
+    """Ensure uv package manager is available, install with pip if not"""
+    try:
+        result = subprocess.run(
+            ["uv", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=3
+        )
+        uv_available = result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        uv_available = False
+    
+    if not uv_available:
+        try:
+            result = subprocess.run(
+                [env.subst("$PYTHONEXE"), "-m", "pip", "install", "uv>=0.1.0", "-q", "-q", "-q"],
+                capture_output=True,
+                text=True,
+                timeout=30  # 30 second timeout
+            )
+            if result.returncode != 0:
+                if result.stderr:
+                    print(f"Error output: {result.stderr.strip()}")
+                return False
+        except subprocess.TimeoutExpired:
+            print("Error: uv installation timed out")
+            return False
+        except FileNotFoundError:
+            print("Error: Python executable not found")
+            return False
+        except Exception as e:
+            print(f"Error installing uv package manager: {e}")
+            return False
+
+    
+    def _get_installed_uv_packages():
+        result = {}
+        try:
+            cmd = ["uv", "pip", "list", "--format=json"]
+            result_obj = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding='utf-8',
+                timeout=30  # 30 second timeout
+            )
+            
+            if result_obj.returncode == 0:
+                content = result_obj.stdout.strip()
+                if content:
+                    packages = json.loads(content)
+                    for p in packages:
+                        result[p["name"]] = pepver_to_semver(p["version"])
+            else:
+                print(f"Warning: pip list failed with exit code {result_obj.returncode}")
+                if result_obj.stderr:
+                    print(f"Error output: {result_obj.stderr.strip()}")
+                
+        except subprocess.TimeoutExpired:
+            print("Warning: uv pip list command timed out")
+        except (json.JSONDecodeError, KeyError) as e:
+            print(f"Warning: Could not parse package list: {e}")
+        except FileNotFoundError:
+            print("Warning: uv command not found")
+        except Exception as e:
+            print(f"Warning! Couldn't extract the list of installed Python packages: {e}")
+
+        return result
+
+    installed_packages = _get_installed_uv_packages()
+    packages_to_install = list(get_packages_to_install(python_deps, installed_packages))
+    
+    if packages_to_install:
+        packages_list = [f"{p}{python_deps[p]}" for p in packages_to_install]
+        
+        cmd = [
+            "uv", "pip", "install",
+            f"--python={env.subst('$PYTHONEXE')}",
+            "--quiet", "--upgrade"
+        ] + packages_list
+        
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30  # 30 second timeout for package installation
+            )
+            
+            if result.returncode != 0:
+                print(f"Error: Failed to install Python dependencies (exit code: {result.returncode})")
+                if result.stderr:
+                    print(f"Error output: {result.stderr.strip()}")
+                return False
+                
+        except subprocess.TimeoutExpired:
+            print("Error: Python dependencies installation timed out")
+            return False
+        except FileNotFoundError:
+            print("Error: uv command not found")
+            return False
+        except Exception as e:
+            print(f"Error installing Python dependencies: {e}")
+            return False
+    
+    return True
+
+
+def _install_esptool(env):
+    """Install esptool from package folder "tool-esptoolpy" using uv package manager"""
+    try:
+        subprocess.check_call([env.subst("$PYTHONEXE"), "-c", "import esptool"], 
+                              stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    esptool_repo_path = env.subst(platform.get_package_dir("tool-esptoolpy") or "")
+    if esptool_repo_path and os.path.isdir(esptool_repo_path):
+        try:
+            subprocess.check_call([
+                "uv", "pip", "install", "--quiet",
+                f"--python={env.subst("$PYTHONEXE")}", 
+                "-e", esptool_repo_path
+            ])
+            return True
+        except subprocess.CalledProcessError as e:
+            print(f"Warning: Failed to install esptool: {e}")
+            return False
+    
+    return False
+
+
+install_python_deps()
+_install_esptool(env)
 
 
 def _install_esptool(env):
@@ -455,6 +618,7 @@ env.Append(
 if not env.get("PIOFRAMEWORK"):
     env.SConscript("frameworks/_bare.py", exports="env")
 
+
 def firmware_metrics(target, source, env):
     """
     Custom target to run esp-idf-size with support for command line parameters
@@ -516,6 +680,7 @@ def firmware_metrics(target, source, env):
     except Exception as e:
         print(f"Error: Failed to run firmware metrics: {e}")
         print("Make sure esp-idf-size is installed: pip install esp-idf-size")
+
 
 #
 # Target: Build executable and linkable firmware or FS image

--- a/builder/main.py
+++ b/builder/main.py
@@ -480,8 +480,6 @@ if mcu in ("esp32c2", "esp32c3", "esp32c5", "esp32c6", "esp32h2", "esp32p4"):
 if "INTEGRATION_EXTRA_DATA" not in env:
     env["INTEGRATION_EXTRA_DATA"] = {}
 
-_install_esptool(env)
-
 # Configure build tools and environment variables
 env.Replace(
     __get_board_boot_mode=_get_board_boot_mode,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced improved Python dependency management and automated esptool installation, ensuring all required packages are present before the build process.

* **Refactor**
  * Switched Python dependency installation for certain frameworks to use the `uv` package manager instead of direct pip calls.
  * Updated dependency lists and installation logic to streamline package handling.

* **Chores**
  * Removed legacy and redundant Python dependency management code from specific framework integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->