### PR TITLE
use full path for uv in espidf

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1484,7 +1484,7 @@ def generate_mbedtls_bundle(sdk_config):
 
 def install_python_deps():
     PYTHON_EXE = env.subst("$PYTHONEXE")
-    UV_EXE = os.path.join(os.path.dirname(PYTHON_EXE), "uv")
+    UV_EXE = os.path.join(os.path.dirname(PYTHON_EXE), "uv" + (".exe" if IS_WINDOWS else ""))
     print(f"Debug - PYTHON_EXE: {PYTHON_EXE}")
     print(f"Debug - UV_EXE: {UV_EXE}")
     def _get_installed_uv_packages(python_exe_path):

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1485,8 +1485,6 @@ def generate_mbedtls_bundle(sdk_config):
 def install_python_deps():
     PYTHON_EXE = env.subst("$PYTHONEXE")
     UV_EXE = os.path.join(os.path.dirname(PYTHON_EXE), "uv" + (".exe" if IS_WINDOWS else ""))
-    print(f"Debug - PYTHON_EXE: {PYTHON_EXE}")
-    print(f"Debug - UV_EXE: {UV_EXE}")
     def _get_installed_uv_packages(python_exe_path):
         result = {}
         try:

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1483,11 +1483,15 @@ def generate_mbedtls_bundle(sdk_config):
 
 
 def install_python_deps():
+    PYTHON_EXE = env.subst("$PYTHONEXE")
+    UV_EXE = os.path.join(os.path.dirname(PYTHON_EXE), "uv")
+    print(f"Debug - PYTHON_EXE: {PYTHON_EXE}")
+    print(f"Debug - UV_EXE: {PIO_EXE}")
     def _get_installed_uv_packages(python_exe_path):
         result = {}
         try:
             uv_output = subprocess.check_output([
-                "uv", "pip", "list", "--python", python_exe_path, "--format=json"
+                UV_EXE, "pip", "list", "--python", python_exe_path, "--format=json"
             ])
             packages = json.loads(uv_output)
         except (subprocess.CalledProcessError, json.JSONDecodeError, OSError) as e:
@@ -1534,7 +1538,7 @@ def install_python_deps():
         # Use uv to install packages in the specific Python environment
         env.Execute(
             env.VerboseAction(
-                f'uv pip install --python "{python_exe_path}" {packages_str}',
+                f'"{UV_EXE}" pip install --python "{python_exe_path}" {packages_str}',
                 "Installing ESP-IDF's Python dependencies with uv",
             )
         )
@@ -1543,7 +1547,7 @@ def install_python_deps():
         # Install windows-curses in the IDF Python environment
         env.Execute(
             env.VerboseAction(
-                f'uv pip install --python "{python_exe_path}" windows-curses',
+                f'"{UV_EXE}" pip install --python "{python_exe_path}" windows-curses',
                 "Installing windows-curses package with uv",
             )
         )

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1486,7 +1486,7 @@ def install_python_deps():
     PYTHON_EXE = env.subst("$PYTHONEXE")
     UV_EXE = os.path.join(os.path.dirname(PYTHON_EXE), "uv")
     print(f"Debug - PYTHON_EXE: {PYTHON_EXE}")
-    print(f"Debug - UV_EXE: {PIO_EXE}")
+    print(f"Debug - UV_EXE: {UV_EXE}")
     def _get_installed_uv_packages(python_exe_path):
         result = {}
         try:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Python dependency installation by ensuring the correct executable is used, regardless of system PATH configuration.
  * Enhanced debug output to display resolved paths for executables during the installation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->