### PR TITLE
Fix/arduino/idf55 debug

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -547,7 +547,7 @@ class Espressif32Platform(PlatformBase):
         """Check if debug tools are needed based on build configuration."""
         return bool(
             variables.get("build_type") or
-            "debug" in targets or
+            "__debug" in targets or
             variables.get("upload_protocol")
         )
 
@@ -572,8 +572,10 @@ class Espressif32Platform(PlatformBase):
         # Debug tools when needed
         if self._needs_debug_tools(variables, targets):
             for debug_tool in mcu_config["debug_tools"]:
-                self.install_tool(debug_tool)
-            self.install_tool("tool-openocd-esp32")
+                #self.install_tool(debug_tool)
+                self.packages[debug_tool]["optional"] = False
+            #self.install_tool("tool-openocd-esp32")
+            self.packages["tool-openocd-esp32"]["optional"] = False
 
     def _configure_installer(self) -> None:
         """Configure the ESP-IDF tools installer with proper version checking."""

--- a/platform.py
+++ b/platform.py
@@ -468,6 +468,11 @@ class Espressif32Platform(PlatformBase):
         ):
             return False
 
+        # safe piopm file currently installed
+        piopm_data = dict()
+        with open(paths['piopm_path'], "r") as f:
+            piopm_data = json.load(f)
+
         # Copy tool files
         tools_path_default = os.path.join(
             os.path.expanduser("~"), ".platformio"
@@ -483,6 +488,8 @@ class Espressif32Platform(PlatformBase):
 
         tl_path = f"file://{os.path.join(tools_path_default, 'tools', tool_name)}"
         pm.install(tl_path)
+        with open(paths["piopm_path"], "w", encoding="utf-8") as f:
+            json.dump(piopm_data, f)
 
         logger.info(f"Tool {tool_name} successfully installed")
         return True
@@ -572,10 +579,8 @@ class Espressif32Platform(PlatformBase):
         # Debug tools when needed
         if self._needs_debug_tools(variables, targets):
             for debug_tool in mcu_config["debug_tools"]:
-                #self.install_tool(debug_tool)
-                self.packages[debug_tool]["optional"] = False
-            #self.install_tool("tool-openocd-esp32")
-            self.packages["tool-openocd-esp32"]["optional"] = False
+                self.install_tool(debug_tool)
+            self.install_tool("tool-openocd-esp32")
 
     def _configure_installer(self) -> None:
         """Configure the ESP-IDF tools installer with proper version checking."""


### PR DESCRIPTION
This fixes debugging (and other package installs like mklittlefs etc.) with Arduino/IDF55. There is two issues addressed:

1. the debug target is called "__debug", while the code checked for "debug"
2. preserve .piopm in _install_with_idf_tools

I don't quite understand the intent of the ~/.platformio/tools overlay, but what I can observe is that when pm.install(tl_path) is called, the resulting installation into ~/.platformio/packages will have missing values in the ~/.platformio/packages/packagename/.pmpio file (specifically owner will be null and the url parameter will be "FULL/PATH/TO/TOOLS/TOONAME/") . The downstream effects of those two values not being set  is that platform.get_package_dir etc. will not work (because the spec in platform.json has owner "pioarduino" which is not null, and also a different URL). The result is that the tools are not correctly installed (reinstallation of mklittlefs, and debugger completely inoperable). The way I tackled the second issue is more a hack, but it works ;) 