### PR TITLE
Use Tasmota IDF 5.3.4 release

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -513,7 +513,7 @@ def populate_idf_env_vars(idf_env):
     if "IDF_TOOLS_PATH" in idf_env:
         del idf_env["IDF_TOOLS_PATH"]
 
-#    idf_env["ESP_ROM_ELF_DIR"] = platform.get_package_dir("tool-esp-rom-elfs")
+    idf_env["ESP_ROM_ELF_DIR"] = platform.get_package_dir("tool-esp-rom-elfs")
 
 
 def get_target_config(project_configs, target_index, cmake_api_reply_dir):

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1512,7 +1512,7 @@ def install_python_deps():
         # https://github.com/platformio/platform-espressif32/issues/635
         "cryptography": "~=44.0.0",
         "pyparsing": ">=3.1.0,<4",
-        "idf-component-manager": "~=2.2.2",
+        "idf-component-manager": "~=2.2",
         "esp-idf-kconfig": "~=2.5.0"
     }
 

--- a/platform.json
+++ b/platform.json
@@ -39,7 +39,7 @@
       "type": "framework",
       "optional": true,
       "owner": "tasmota",
-      "version": "https://github.com/pioarduino/esp-idf/releases/download/v5.3.4/esp-idf-v5.3.4.zip"
+      "version": "https://github.com/tasmota/esp-idf/releases/download/v5.3.4/esp-idf-v5.3.4.zip"
     },
     "toolchain-xtensa-esp-elf": {
       "type": "toolchain",

--- a/platform.json
+++ b/platform.json
@@ -39,7 +39,7 @@
       "type": "framework",
       "optional": true,
       "owner": "tasmota",
-      "version": "https://github.com/tasmota/esp-idf/releases/download/v5.3.4.250815/esp-idf-v5.3.4.zip"
+      "version": "https://github.com/pioarduino/esp-idf/releases/download/v5.3.4/esp-idf-v5.3.4.zip"
     },
     "toolchain-xtensa-esp-elf": {
       "type": "toolchain",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled use of bundled ROM ELF files for ESP targets, improving symbol availability during development.
- Bug Fixes
  - Updated ESP-IDF download to the official v5.3.4 release source for more reliable framework installation.
- Chores
  - Relaxed the minimum version constraint for the ESP-IDF component manager dependency to allow broader compatible installations and reduce unnecessary upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->