### PR TITLE
Refactor components directory path handling (Symlinks)

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -302,12 +302,7 @@ class PathCache:
     def sdk_dir(self):
         if self._sdk_dir is None:
             self._sdk_dir = fs.to_unix_path(
-                join(self.framework_dir,
-                     "tools",
-                     "esp32-arduino-libs",
-                     self.mcu,
-                     "include"
-                )
+                str(Path(self.framework_dir) / "tools" / "esp32-arduino-libs" / self.mcu / "include")
             )
         return self._sdk_dir
 
@@ -495,7 +490,7 @@ def safe_remove_sdkconfig_files():
     envs = [section.replace("env:", "") for section in config.sections()
             if section.startswith("env:")]
     for env_name in envs:
-        file_path = join(project_dir, f"sdkconfig.{env_name}")
+        file_path = str(Path(project_dir) / f"sdkconfig.{env_name}")
         if exists(file_path):
             safe_delete_file(file_path)
 
@@ -550,9 +545,7 @@ FRAMEWORK_DIR = path_cache.framework_dir
 
 SConscript("_embed_files.py", exports="env")
 
-flag_any_custom_sdkconfig = exists(join(
-    FRAMEWORK_DIR, "tools", "esp32-arduino-libs",
-    "sdkconfig"))
+flag_any_custom_sdkconfig = exists(str(Path(FRAMEWORK_DIR) / "tools" / "esp32-arduino-libs" / "sdkconfig"))
 
 
 def has_unicore_flags():
@@ -583,7 +576,7 @@ def matching_custom_sdkconfig():
     if not flag_any_custom_sdkconfig:
         return True, cust_sdk_is_present
 
-    last_sdkconfig_path = join(project_dir, "sdkconfig.defaults")
+    last_sdkconfig_path = str(Path(project_dir) / "sdkconfig.defaults")
     if not exists(last_sdkconfig_path):
         return False, cust_sdk_is_present
 
@@ -889,5 +882,5 @@ if ("arduino" in pioframework and "espidf" not in pioframework and
     if IS_WINDOWS:
         env.AddBuildMiddleware(smart_include_length_shorten)
 
-    build_script_path = join(FRAMEWORK_DIR, "tools", "pioarduino-build.py")
+    build_script_path = str(Path(FRAMEWORK_DIR) / "tools" / "pioarduino-build.py")
     SConscript(build_script_path)

--- a/builder/frameworks/component_manager.py
+++ b/builder/frameworks/component_manager.py
@@ -1055,19 +1055,21 @@ class BackupManager:
 
 class ComponentManager:
     """
-    Main component manager class that orchestrates all component operations.
+    Main component manager that orchestrates all operations.
     
-    This class provides the primary interface for PlatformIO build scripts,
-    coordinating between component handling, library ignore processing,
-    and build script restoration operations.
+    Primary interface for component management operations, coordinating
+    between specialized handlers for components, libraries, and backups.
+    Uses composition pattern to organize functionality into focused classes.
     """
     
     def __init__(self, env):
         """
-        Initialize the component manager with PlatformIO environment.
+        Initialize the ComponentManager with composition pattern.
         
-        Sets up all necessary configuration, logging, and handler instances
-        for managing ESP-IDF components within Arduino framework projects.
+        Creates and configures all specialized handler instances using
+        the composition pattern for better separation of concerns and
+        maintainability. Each handler focuses on a specific aspect
+        of component management.
         
         Args:
             env: PlatformIO environment object containing project configuration
@@ -1075,51 +1077,69 @@ class ComponentManager:
         self.config = ComponentManagerConfig(env)
         self.logger = ComponentLogger()
         self.component_handler = ComponentHandler(self.config, self.logger)
-        self.lib_ignore_handler = LibraryIgnoreHandler(self.config, self.logger)
+        self.library_handler = LibraryIgnoreHandler(self.config, self.logger)
+        self.backup_manager = BackupManager(self.config)
     
-    def handle_component_settings(self) -> None:
+    def handle_component_settings(self, add_components: bool = False, remove_components: bool = False) -> None:
         """
-        Main entry point for component management operations.
+        Handle component operations by delegating to specialized handlers.
         
-        Processes both component additions/removals and library ignore
-        operations based on the project configuration. Determines which
-        operations to perform based on configured options.
+        Main entry point for component management operations. Coordinates
+        component addition/removal and library ignore processing, then
+        provides a summary of all changes made during the session.
+        
+        Args:
+            add_components: Whether to process component additions from configuration
+            remove_components: Whether to process component removals from configuration
         """
-        # Check for component operations
-        has_add = self.config.config.has_option(f"env:{self.config.env['PIOENV']}", "custom_component_add")
-        has_remove = self.config.config.has_option(f"env:{self.config.env['PIOENV']}", "custom_component_remove")
-        has_lib_ignore = self.config.config.has_option(f"env:{self.config.env['PIOENV']}", "lib_ignore")
+        self.component_handler.handle_component_settings(add_components, remove_components)
+        self.library_handler.handle_lib_ignore()
         
-        # Handle component operations
-        if has_add or has_remove:
-            self.component_handler.handle_component_settings(
-                add_components=has_add,
-                remove_components=has_remove
-            )
-        
-        # Handle library ignore operations
-        if has_lib_ignore:
-            self.lib_ignore_handler.handle_lib_ignore()
+        # Print summary
+        changes = self.logger.get_changes_summary()
+        if changes:
+            self.logger.log_change(f"Session completed with {len(changes)} changes")
     
-    def restore_pioarduino_build_py(self) -> None:
+    def handle_lib_ignore(self) -> None:
         """
-        Restore the original pioarduino-build.py file from backup.
+        Delegate lib_ignore handling to specialized handler.
         
-        Restores the Arduino build script from its backup copy and
-        cleans up temporary backup files. This method is typically
-        called after build completion to restore the original state.
+        Provides direct access to library ignore processing for cases
+        where only library handling is needed without component operations.
         """
-        if "arduino" not in self.config.env.subst("$PIOFRAMEWORK"):
-            return
+        self.library_handler.handle_lib_ignore()
+    
+    def restore_pioarduino_build_py(self, target=None, source=None, env=None) -> None:
+        """
+        Delegate backup restoration to backup manager.
         
-        build_py_path = str(Path(self.config.arduino_libs_mcu) / "pioarduino-build.py")
-        backup_path = str(Path(self.config.arduino_libs_mcu) / f"pioarduino-build.py.{self.config.mcu}")
+        Provides access to backup restoration functionality, typically
+        used during clean operations or build environment resets.
         
-        try:
-            if os.path.exists(backup_path):
-                if os.path.exists(build_py_path):
-                    os.remove(build_py_path)
-                shutil.move(backup_path, build_py_path)
-                self.logger.log_change("Restored original build file")
-        except Exception as e:
-            self.logger.log_change(f"Error restoring build file: {str(e)}")
+        Args:
+            target: Build target (unused, for PlatformIO compatibility)
+            source: Build source (unused, for PlatformIO compatibility)
+            env: Environment (unused, for PlatformIO compatibility)
+        """
+        self.backup_manager.restore_pioarduino_build_py(target, source, env)
+    
+    def get_changes_summary(self) -> List[str]:
+        """
+        Get summary of changes from logger.
+        
+        Provides access to the complete list of changes made during
+        the current session for reporting or debugging purposes.
+        
+        Returns:
+            List of change messages in chronological order
+        """
+        return self.logger.get_changes_summary()
+    
+    def print_changes_summary(self) -> None:
+        """
+        Print changes summary via logger.
+        
+        Outputs a formatted summary of all changes made during the
+        session, useful for build reporting and debugging.
+        """
+        self.logger.print_changes_summary()

--- a/builder/frameworks/component_manager.py
+++ b/builder/frameworks/component_manager.py
@@ -668,7 +668,10 @@ class LibraryIgnoreHandler:
         libraries_mapping = {}
         
         # Path to Arduino Core Libraries
-        arduino_libs_dir = str(Path(self.config.arduino_framework_dir) / "libraries")
+        afd = self.config.arduino_framework_dir
+        if not afd:
+            return libraries_mapping
+        arduino_libs_dir = str(Path(afd).resolve() / "libraries")
         
         if not os.path.exists(arduino_libs_dir):
             return libraries_mapping

--- a/builder/frameworks/component_manager.py
+++ b/builder/frameworks/component_manager.py
@@ -925,7 +925,7 @@ class LibraryIgnoreHandler:
                     rf'.*"[^"]*{re.escape(lib_name)}[^"]*include[^"]*"[^,\n]*,?\n',
                     rf'.*join\([^)]*"include"[^)]*"{re.escape(lib_name)}"[^)]*\),?\n',
                     rf'.*"{re.escape(lib_name)}/include"[^,\n]*,?\n',
-                    rf'\s*"[^"]*/{re.escape(lib_name)}/[^"]*",?\n',
+                    rf'\s*"[^"]*[\\/]{re.escape(lib_name)}[\\/][^"]*",?\n',
                     # pathlib-style: Path(...)/"include"/"<name>"
                     rf'.*Path\([^)]*\)\s*/\s*"include"\s*/\s*"{re.escape(lib_name)}"[^,\n]*,?\n',
                     rf'.*Path\([^)]*{re.escape(lib_name)}[^)]*\)\s*/\s*"include"[^,\n]*,?\n'

--- a/builder/frameworks/component_manager.py
+++ b/builder/frameworks/component_manager.py
@@ -837,7 +837,7 @@ class LibraryIgnoreHandler:
             Converted include directory name for path removal
         """
         # Load Arduino Core Libraries on first call
-        if not hasattr(self, '_arduino_libraries_cache'):
+        if self._arduino_libraries_cache is None:
             self._arduino_libraries_cache = self._get_arduino_core_libraries()
         
         lib_name_lower = lib_name.lower()
@@ -925,7 +925,11 @@ class LibraryIgnoreHandler:
                     rf'.*"[^"]*{re.escape(lib_name)}[^"]*include[^"]*"[^,\n]*,?\n',
                     rf'.*join\([^)]*"include"[^)]*"{re.escape(lib_name)}"[^)]*\),?\n',
                     rf'.*"{re.escape(lib_name)}/include"[^,\n]*,?\n',
-                    rf'\s*"[^"]*/{re.escape(lib_name)}/[^"]*",?\n'
+                    rf'\s*"[^"]*/{re.escape(lib_name)}/[^"]*",?\n',
+                    # pathlib-style: Path(...)/"include"/"<name>"
+                    rf'.*Path\([^)]*\)\s*/\s*"include"\s*/\s*"{re.escape(lib_name)}"[^,\n]*,?\n',
+                    rf'.*Path\([^)]*{re.escape(lib_name)}[^)]*\)\s*/\s*"include"[^,\n]*,?\n'
+                 ]
                 ]
                 
                 removed_count = 0

--- a/builder/frameworks/component_manager.py
+++ b/builder/frameworks/component_manager.py
@@ -13,7 +13,7 @@ import shutil
 import re
 import yaml
 from yaml import SafeLoader
-from os.path import join
+from pathlib import Path
 from typing import Set, Optional, Dict, Any, List, Tuple
 
 
@@ -50,7 +50,7 @@ class ComponentManagerConfig:
         # Get Arduino framework installation directory
         self.arduino_framework_dir = self.platform.get_package_dir("framework-arduinoespressif32")
         # Get MCU-specific Arduino libraries directory
-        self.arduino_libs_mcu = join(self.arduino_framework_dir, "tools", "esp32-arduino-libs", self.mcu)
+        self.arduino_libs_mcu = str(Path(self.arduino_framework_dir) / "tools" / "esp32-arduino-libs" / self.mcu)
 
 
 class ComponentLogger:
@@ -228,13 +228,13 @@ class ComponentHandler:
             Absolute path to the component YAML file
         """
         # Try Arduino framework first
-        framework_yml = join(self.config.arduino_framework_dir, "idf_component.yml")
+        framework_yml = str(Path(self.config.arduino_framework_dir) / "idf_component.yml")
         if os.path.exists(framework_yml):
             self._create_backup(framework_yml)
             return framework_yml
         
         # Try project source directory
-        project_yml = join(self.config.project_src_dir, "idf_component.yml")
+        project_yml = str(Path(self.config.project_src_dir) / "idf_component.yml")
         if os.path.exists(project_yml):
             self._create_backup(project_yml)
             return project_yml
@@ -417,8 +417,8 @@ class ComponentHandler:
         if "arduino" not in self.config.env.subst("$PIOFRAMEWORK"):
             return
         
-        build_py_path = join(self.config.arduino_libs_mcu, "pioarduino-build.py")
-        backup_path = join(self.config.arduino_libs_mcu, f"pioarduino-build.py.{self.config.mcu}")
+        build_py_path = str(Path(self.config.arduino_libs_mcu) / "pioarduino-build.py")
+        backup_path = str(Path(self.config.arduino_libs_mcu) / f"pioarduino-build.py.{self.config.mcu}")
         
         if os.path.exists(build_py_path) and not os.path.exists(backup_path):
             shutil.copy2(build_py_path, backup_path)
@@ -446,7 +446,7 @@ class ComponentHandler:
         Args:
             component: Component name in filesystem format
         """
-        include_path = join(self.config.arduino_libs_mcu, "include", component)
+        include_path = str(Path(self.config.arduino_libs_mcu) / "include" / component)
         
         if os.path.exists(include_path):
             shutil.rmtree(include_path)
@@ -459,7 +459,7 @@ class ComponentHandler:
         for all components that were removed from the project. Uses
         multiple regex patterns to catch different include path formats.
         """
-        build_py_path = join(self.config.arduino_libs_mcu, "pioarduino-build.py")
+        build_py_path = str(Path(self.config.arduino_libs_mcu) / "pioarduino-build.py")
         
         if not os.path.exists(build_py_path):
             return
@@ -665,14 +665,14 @@ class LibraryIgnoreHandler:
         libraries_mapping = {}
         
         # Path to Arduino Core Libraries
-        arduino_libs_dir = join(self.config.arduino_framework_dir, "libraries")
+        arduino_libs_dir = str(Path(self.config.arduino_framework_dir) / "libraries")
         
         if not os.path.exists(arduino_libs_dir):
             return libraries_mapping
         
         try:
             for entry in os.listdir(arduino_libs_dir):
-                lib_path = join(arduino_libs_dir, entry)
+                lib_path = str(Path(arduino_libs_dir) / entry)
                 if os.path.isdir(lib_path):
                     lib_name = self._get_library_name_from_properties(lib_path)
                     if lib_name:
@@ -697,7 +697,7 @@ class LibraryIgnoreHandler:
         Returns:
             Official library name or None if not found or readable
         """
-        prop_path = join(lib_dir, "library.properties")
+        prop_path = str(Path(lib_dir) / "library.properties")
         if not os.path.isfile(prop_path):
             return None
         
@@ -886,7 +886,7 @@ class LibraryIgnoreHandler:
         components when dependencies are detected. Uses multiple regex
         patterns to catch different include path formats.
         """
-        build_py_path = join(self.config.arduino_libs_mcu, "pioarduino-build.py")
+        build_py_path = str(Path(self.config.arduino_libs_mcu) / "pioarduino-build.py")
         
         if not os.path.exists(build_py_path):
             self.logger.log_change("Build file not found")
@@ -987,8 +987,8 @@ class LibraryIgnoreHandler:
         if "arduino" not in self.config.env.subst("$PIOFRAMEWORK"):
             return
         
-        build_py_path = join(self.config.arduino_libs_mcu, "pioarduino-build.py")
-        backup_path = join(self.config.arduino_libs_mcu, f"pioarduino-build.py.{self.config.mcu}")
+        build_py_path = str(Path(self.config.arduino_libs_mcu) / "pioarduino-build.py")
+        backup_path = str(Path(self.config.arduino_libs_mcu) / f"pioarduino-build.py.{self.config.mcu}")
         
         if os.path.exists(build_py_path) and not os.path.exists(backup_path):
             shutil.copy2(build_py_path, backup_path)
@@ -1002,7 +1002,7 @@ class BackupManager:
     framework build scripts, ensuring that original files can be restored
     when needed or when builds are cleaned.
     """
-    
+
     def __init__(self, config: ComponentManagerConfig):
         """
         Initialize the backup manager with configuration access.
@@ -1014,7 +1014,7 @@ class BackupManager:
             config: Configuration manager instance providing access to paths
         """
         self.config = config
-    
+
     def backup_pioarduino_build_py(self) -> None:
         """
         Create backup of the original pioarduino-build.py file.
@@ -1025,13 +1025,13 @@ class BackupManager:
         """
         if "arduino" not in self.config.env.subst("$PIOFRAMEWORK"):
             return
-        
-        build_py_path = join(self.config.arduino_libs_mcu, "pioarduino-build.py")
-        backup_path = join(self.config.arduino_libs_mcu, f"pioarduino-build.py.{self.config.mcu}")
-        
+
+        build_py_path = str(Path(self.config.arduino_libs_mcu) / "pioarduino-build.py")
+        backup_path = str(Path(self.config.arduino_libs_mcu) / f"pioarduino-build.py.{self.config.mcu}")
+
         if os.path.exists(build_py_path) and not os.path.exists(backup_path):
             shutil.copy2(build_py_path, backup_path)
-    
+
     def restore_pioarduino_build_py(self, target=None, source=None, env=None) -> None:
         """
         Restore the original pioarduino-build.py from backup.
@@ -1045,9 +1045,9 @@ class BackupManager:
             source: Build source (unused, for PlatformIO compatibility)
             env: Environment (unused, for PlatformIO compatibility)
         """
-        build_py_path = join(self.config.arduino_libs_mcu, "pioarduino-build.py")
-        backup_path = join(self.config.arduino_libs_mcu, f"pioarduino-build.py.{self.config.mcu}")
-        
+        build_py_path = str(Path(self.config.arduino_libs_mcu) / "pioarduino-build.py")
+        backup_path = str(Path(self.config.arduino_libs_mcu) / f"pioarduino-build.py.{self.config.mcu}")
+
         if os.path.exists(backup_path):
             shutil.copy2(backup_path, build_py_path)
             os.remove(backup_path)
@@ -1055,21 +1055,19 @@ class BackupManager:
 
 class ComponentManager:
     """
-    Main component manager that orchestrates all operations.
+    Main component manager class that orchestrates all component operations.
     
-    Primary interface for component management operations, coordinating
-    between specialized handlers for components, libraries, and backups.
-    Uses composition pattern to organize functionality into focused classes.
+    This class provides the primary interface for PlatformIO build scripts,
+    coordinating between component handling, library ignore processing,
+    and build script restoration operations.
     """
     
     def __init__(self, env):
         """
-        Initialize the ComponentManager with composition pattern.
+        Initialize the component manager with PlatformIO environment.
         
-        Creates and configures all specialized handler instances using
-        the composition pattern for better separation of concerns and
-        maintainability. Each handler focuses on a specific aspect
-        of component management.
+        Sets up all necessary configuration, logging, and handler instances
+        for managing ESP-IDF components within Arduino framework projects.
         
         Args:
             env: PlatformIO environment object containing project configuration
@@ -1077,69 +1075,51 @@ class ComponentManager:
         self.config = ComponentManagerConfig(env)
         self.logger = ComponentLogger()
         self.component_handler = ComponentHandler(self.config, self.logger)
-        self.library_handler = LibraryIgnoreHandler(self.config, self.logger)
-        self.backup_manager = BackupManager(self.config)
+        self.lib_ignore_handler = LibraryIgnoreHandler(self.config, self.logger)
     
-    def handle_component_settings(self, add_components: bool = False, remove_components: bool = False) -> None:
+    def handle_component_settings(self) -> None:
         """
-        Handle component operations by delegating to specialized handlers.
+        Main entry point for component management operations.
         
-        Main entry point for component management operations. Coordinates
-        component addition/removal and library ignore processing, then
-        provides a summary of all changes made during the session.
-        
-        Args:
-            add_components: Whether to process component additions from configuration
-            remove_components: Whether to process component removals from configuration
+        Processes both component additions/removals and library ignore
+        operations based on the project configuration. Determines which
+        operations to perform based on configured options.
         """
-        self.component_handler.handle_component_settings(add_components, remove_components)
-        self.library_handler.handle_lib_ignore()
+        # Check for component operations
+        has_add = self.config.config.has_option(f"env:{self.config.env['PIOENV']}", "custom_component_add")
+        has_remove = self.config.config.has_option(f"env:{self.config.env['PIOENV']}", "custom_component_remove")
+        has_lib_ignore = self.config.config.has_option(f"env:{self.config.env['PIOENV']}", "lib_ignore")
         
-        # Print summary
-        changes = self.logger.get_changes_summary()
-        if changes:
-            self.logger.log_change(f"Session completed with {len(changes)} changes")
+        # Handle component operations
+        if has_add or has_remove:
+            self.component_handler.handle_component_settings(
+                add_components=has_add,
+                remove_components=has_remove
+            )
+        
+        # Handle library ignore operations
+        if has_lib_ignore:
+            self.lib_ignore_handler.handle_lib_ignore()
     
-    def handle_lib_ignore(self) -> None:
+    def restore_pioarduino_build_py(self) -> None:
         """
-        Delegate lib_ignore handling to specialized handler.
+        Restore the original pioarduino-build.py file from backup.
         
-        Provides direct access to library ignore processing for cases
-        where only library handling is needed without component operations.
+        Restores the Arduino build script from its backup copy and
+        cleans up temporary backup files. This method is typically
+        called after build completion to restore the original state.
         """
-        self.library_handler.handle_lib_ignore()
-    
-    def restore_pioarduino_build_py(self, target=None, source=None, env=None) -> None:
-        """
-        Delegate backup restoration to backup manager.
+        if "arduino" not in self.config.env.subst("$PIOFRAMEWORK"):
+            return
         
-        Provides access to backup restoration functionality, typically
-        used during clean operations or build environment resets.
+        build_py_path = str(Path(self.config.arduino_libs_mcu) / "pioarduino-build.py")
+        backup_path = str(Path(self.config.arduino_libs_mcu) / f"pioarduino-build.py.{self.config.mcu}")
         
-        Args:
-            target: Build target (unused, for PlatformIO compatibility)
-            source: Build source (unused, for PlatformIO compatibility)
-            env: Environment (unused, for PlatformIO compatibility)
-        """
-        self.backup_manager.restore_pioarduino_build_py(target, source, env)
-    
-    def get_changes_summary(self) -> List[str]:
-        """
-        Get summary of changes from logger.
-        
-        Provides access to the complete list of changes made during
-        the current session for reporting or debugging purposes.
-        
-        Returns:
-            List of change messages in chronological order
-        """
-        return self.logger.get_changes_summary()
-    
-    def print_changes_summary(self) -> None:
-        """
-        Print changes summary via logger.
-        
-        Outputs a formatted summary of all changes made during the
-        session, useful for build reporting and debugging.
-        """
-        self.logger.print_changes_summary()
+        try:
+            if os.path.exists(backup_path):
+                if os.path.exists(build_py_path):
+                    os.remove(build_py_path)
+                shutil.move(backup_path, build_py_path)
+                self.logger.log_change("Restored original build file")
+        except Exception as e:
+            self.logger.log_change(f"Error restoring build file: {str(e)}")

--- a/builder/frameworks/component_manager.py
+++ b/builder/frameworks/component_manager.py
@@ -416,7 +416,10 @@ class ComponentHandler:
         """
         if "arduino" not in self.config.env.subst("$PIOFRAMEWORK"):
             return
-        
+
+        if not self.config.arduino_libs_mcu:
+            return
+
         build_py_path = str(Path(self.config.arduino_libs_mcu) / "pioarduino-build.py")
         backup_path = str(Path(self.config.arduino_libs_mcu) / f"pioarduino-build.py.{self.config.mcu}")
         

--- a/builder/frameworks/component_manager.py
+++ b/builder/frameworks/component_manager.py
@@ -929,7 +929,6 @@ class LibraryIgnoreHandler:
                     # pathlib-style: Path(...)/"include"/"<name>"
                     rf'.*Path\([^)]*\)\s*/\s*"include"\s*/\s*"{re.escape(lib_name)}"[^,\n]*,?\n',
                     rf'.*Path\([^)]*{re.escape(lib_name)}[^)]*\)\s*/\s*"include"[^,\n]*,?\n'
-                 ]
                 ]
                 
                 removed_count = 0

--- a/builder/frameworks/component_manager.py
+++ b/builder/frameworks/component_manager.py
@@ -990,6 +990,8 @@ class LibraryIgnoreHandler:
         if "arduino" not in self.config.env.subst("$PIOFRAMEWORK"):
             return
         
+        if not self.config.arduino_libs_mcu:
+            return
         build_py_path = str(Path(self.config.arduino_libs_mcu) / "pioarduino-build.py")
         backup_path = str(Path(self.config.arduino_libs_mcu) / f"pioarduino-build.py.{self.config.mcu}")
         

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1017,9 +1017,10 @@ def compile_source_files(
                 src_path = os.path.join(project_src_dir, src_path)
 
             obj_path = os.path.join("$BUILD_DIR", prepend_dir or "")
-            if str(Path(src_path).resolve()).lower().startswith(components_dir.lower()):
+            resolved_src_path = str(Path(src_path).resolve())
+            if resolved_src_path.lower().startswith(components_dir.lower()):
                 obj_path = os.path.join(
-                    obj_path, os.path.relpath(src_path, components_dir)
+                    obj_path, os.path.relpath(resolved_src_path, components_dir)
                 )
             else:
                 if not os.path.isabs(source["path"]):

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -446,11 +446,11 @@ def normalize_path(path):
     return fs.to_unix_path(path)
 
 
-CMK_DIR = platform.get_package_dir("tool-cmake")
-if not CMK_DIR or not os.path.isdir(CMK_DIR):
-    sys.stderr.write(f"Error: Missing CMake package directory '{CMK_DIR}'\n")
+CMK_TOOL = platform.get_package_dir("tool-cmake")
+if not CMK_TOOL or not os.path.isdir(CMK_TOOL):
+    sys.stderr.write(f"Error: Missing CMake package directory '{CMK_TOOL}'\n")
     env.Exit(1)
-CMAKE_EXE = str(Path(CMK_DIR) / "bin" / "cmake")
+CMAKE_DIR = str(Path(CMK_DIR) / "bin" / "cmake")
 
 
 def create_default_project_files():
@@ -522,7 +522,7 @@ def populate_idf_env_vars(idf_env):
     additional_packages = [
         str(Path(TOOLCHAIN_DIR) / "bin"),
         NINJA_DIR,
-        CMAKE_EXE,
+        CMAKE_DIR,
         os.path.dirname(get_python_exe()),
     ]
 
@@ -1050,7 +1050,7 @@ def RunMenuconfig(target, source, env):
 
     rc = subprocess.call(
         [
-            CMAKE_EXE,
+            CMAKE_DIR,
             "--build",
             BUILD_DIR,
             "--target",
@@ -1066,7 +1066,7 @@ def RunMenuconfig(target, source, env):
 
 def run_cmake(src_dir, build_dir, extra_args=None):
     cmd = [
-        CMAKE_EXE,
+        CMAKE_DIR,
         "-S",
         src_dir,
         "-B",

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1913,15 +1913,9 @@ env.Prepend(
 # Propagate Arduino defines to the main build environment
 #
 
-if "arduino" in env.subst("$PIOFRAMEWORK"):
-    arduino_config_name = list(
-        filter(
-            lambda config_name: config_name.startswith(
-                "__idf_framework-arduinoespressif32"
-            ),
-            target_configs,
-        )
-    )[0]
+arduino_candidates = [n for n in target_configs if n.startswith("__idf_framework-arduinoespressif32")]
+if arduino_candidates:
+    arduino_config_name = arduino_candidates[0]
     env.AppendUnique(
         CPPDEFINES=extract_defines(
             target_configs.get(arduino_config_name, {}).get("compileGroups", [])[0]

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -89,8 +89,12 @@ TOOLCHAIN_DIR = platform.get_package_dir(
 )
 PLATFORMIO_DIR = env.subst("$PROJECT_CORE_DIR")
 
-assert os.path.isdir(FRAMEWORK_DIR)
-assert os.path.isdir(TOOLCHAIN_DIR)
+if not os.path.isdir(FRAMEWORK_DIR):
+    sys.stderr.write(f"Error: Missing framework directory '{FRAMEWORK_DIR}'\n")
+    env.Exit(1)
+if not os.path.isdir(TOOLCHAIN_DIR):
+    sys.stderr.write(f"Error: Missing toolchain directory '{TOOLCHAIN_DIR}'\n")
+    env.Exit(1)
 
 
 def create_silent_action(action_func):
@@ -730,14 +734,10 @@ def load_component_paths(framework_components_dir, ignored_component_prefixes=No
             try:
                 data = json.load(fp)
                 for path in data.get("build_component_paths", []):
-                    if not os.path.basename(path).startswith(
-                        ignored_component_prefixes
-                    ):
+                    if not os.path.basename(path).startswith(ignored_component_prefixes):
                         components.append(path)
-            except:
-                print(
-                    "Warning: Could not find load components from project description!\n"
-                )
+            except (OSError, ValueError) as e:
+                print(f"Warning: Could not load components from project description: {e}\n")
 
     return components or _scan_components_from_framework()
 
@@ -1537,7 +1537,7 @@ def ensure_python_venv_available():
                     )
                     return True
                 return False
-        except:
+        except (OSError, ValueError):
             return True
 
     def _create_venv(venv_dir):
@@ -2100,9 +2100,10 @@ if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PI
 if "espidf" in env.subst("$PIOFRAMEWORK") and (flag_custom_component_add == True or flag_custom_component_remove == True):
     def idf_custom_component(source, target, env):
         try:
-            shutil.copy(str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml.orig"), str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml"))
+            shutil.copy(str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml.orig"),
+                        str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml"))
             print("*** Original Arduino \"idf_component.yml\" restored ***")
-        except:
+        except (FileNotFoundError, PermissionError, OSError):
             try:
                 shutil.copy(str(Path(PROJECT_SRC_DIR) / "idf_component.yml.orig"), str(Path(PROJECT_SRC_DIR) / "idf_component.yml"))
                 print("*** Original \"idf_component.yml\" restored ***")

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -84,7 +84,8 @@ IDF5 = (
     .startswith("5")
 )
 IDF_ENV_VERSION = "1.0.0"
-FRAMEWORK_DIR = platform.get_package_dir("framework-espidf")
+FRAMEWORK_DIR_PATH = Path(platform.get_package_dir("framework-espidf")).resolve()
+FRAMEWORK_DIR = str(FRAMEWORK_DIR_PATH)
 TOOLCHAIN_DIR = platform.get_package_dir(
     "toolchain-xtensa-esp-elf"
     if mcu in ("esp32", "esp32s2", "esp32s3")
@@ -103,7 +104,8 @@ def create_silent_action(action_func):
     return silent_action
 
 if "arduino" in env.subst("$PIOFRAMEWORK"):
-    ARDUINO_FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
+    ARDUINO_FRAMEWORK_DIR_PATH = Path(platform.get_package_dir("framework-arduinoespressif32")).resolve()
+    ARDUINO_FRAMEWORK_DIR = str(ARDUINO_FRAMEWORK_DIR_PATH)
     # Possible package names in 'package@version' format is not compatible with CMake
     if "@" in os.path.basename(ARDUINO_FRAMEWORK_DIR):
         new_path = os.path.join(
@@ -1924,7 +1926,9 @@ except:
 # Remove project source files from following build stages as they're
 # built as part of the framework
 def _skip_prj_source_files(node):
-    if node.srcnode().get_path().lower().startswith(PROJECT_SRC_DIR.lower()):
+    resolved_project_src = str(Path(PROJECT_SRC_DIR).resolve())
+    resolved_node_path = str(Path(node.srcnode().get_path()).resolve())
+    if resolved_node_path.lower().startswith(resolved_project_src.lower()):
         return None
     return node
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2026,7 +2026,7 @@ if os.path.isdir(ulp_dir) and os.listdir(ulp_dir) and mcu not in ("esp32c2", "es
 #
 
 if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PIOFRAMEWORK")):
-    def idf_lib_copy(_source, _target, env):
+    def idf_lib_copy(source, target, env):
         def _replace_move(src, dst):
             dst_p = Path(dst)
             dst_p.parent.mkdir(parents=True, exist_ok=True)

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -999,10 +999,9 @@ def compile_source_files(
 ):
     build_envs = prepare_build_envs(config, default_env, debug_allowed)
     objects = []
-    # The source "path" will have had any symlinks resolved, so resolve any
-    components_dir = str(
-        Path(fs.to_unix_path(os.path.join(FRAMEWORK_DIR, "components"))).resolve()
-    )
+    # Canonical, symlink-resolved absolute path of the components directory
+    components_dir_path = Path(FRAMEWORK_DIR, "components").resolve()
+    components_dir = str(components_dir_path)
     for source in config.get("sources", []):
         if source["path"].endswith(".rule"):
             continue

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -450,7 +450,8 @@ CMK_DIR = platform.get_package_dir("tool-cmake")
 if not CMK_DIR or not os.path.isdir(CMK_DIR):
     sys.stderr.write(f"Error: Missing CMake package directory '{CMK_DIR}'\n")
     env.Exit(1)
-CMAKE_EXE = str(Path(CMK_DIR) / "bin" / "cmake")
+cmake_name = "cmake.exe" if IS_WINDOWS else "cmake"
+CMAKE_EXE = str(Path(CMK_DIR) / "bin" / _cmake_name)
 
 
 def create_default_project_files():
@@ -515,10 +516,14 @@ def get_cmake_code_model(src_dir, build_dir, extra_args=None):
 
 def populate_idf_env_vars(idf_env):
     idf_env["IDF_PATH"] = fs.to_unix_path(FRAMEWORK_DIR)
+    NINJA_DIR = platform.get_package_dir("tool-ninja")
+    if not NINJA_DIR or not os.path.isdir(NINJA_DIR):
+        sys.stderr.write(f"Error: Missing ninja package directory '{NINJA_DIR}'\n")
+        env.Exit(1)
     additional_packages = [
         str(Path(TOOLCHAIN_DIR) / "bin"),
-        platform.get_package_dir("tool-ninja"),
-        CMAKE_EXE
+        NINJA_DIR,
+        str(Path(CMAKE_EXE).parent),
         os.path.dirname(get_python_exe()),
     ]
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -981,8 +981,8 @@ def compile_source_files(
                 src_dir = str(Path(project_src_dir) / config["paths"]["source"])
             src_path = source.get("path")
             if not os.path.isabs(src_path):
-                # Resolve relative to the component's source dir
-                src_path = str(Path(src_dir) / src_path)
+                # For cases when sources are located near CMakeLists.txt
+                src_path = str(Path(project_src_dir) / src_path)
 
             obj_path = str(Path("$BUILD_DIR") / (prepend_dir or ""))
             src_path_obj = Path(src_path).resolve()

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -450,7 +450,7 @@ CMK_TOOL = platform.get_package_dir("tool-cmake")
 if not CMK_TOOL or not os.path.isdir(CMK_TOOL):
     sys.stderr.write(f"Error: Missing CMake package directory '{CMK_TOOL}'\n")
     env.Exit(1)
-CMAKE_DIR = str(Path(CMK_DIR) / "bin" / "cmake")
+CMAKE_DIR = str(Path(CMK_TOOL) / "bin" / "cmake")
 
 
 def create_default_project_files():

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -483,8 +483,8 @@ def get_cmake_code_model(src_dir, build_dir, extra_args=None):
     query_file = str(Path(cmake_api_query_dir) / "codemodel-v2")
 
     if not os.path.isfile(query_file):
-        os.makedirs(os.path.dirname(query_file))
-        open(query_file, "a").close()  # create an empty file
+        Path(cmake_api_query_dir).mkdir(parents=True, exist_ok=True)
+        Path(query_file).touch()
 
     if not is_proper_idf_project():
         create_default_project_files()
@@ -1006,11 +1006,6 @@ def compile_source_files(
                     obj_path = str(Path(obj_path) / source["path"])
                 else:
                     obj_path = str(Path(obj_path) / os.path.basename(src_path))
-            else:
-                if not os.path.isabs(source["path"]):
-                    obj_path = str(Path(obj_path) / source["path"])
-                else:
-                    obj_path = str(Path(obj_path) / os.path.basename(src_path))
 
             preserve_source_file_extension = board.get(
                 "build.esp-idf.preserve_source_file_extension", "yes"
@@ -1067,7 +1062,7 @@ def RunMenuconfig(target, source, env):
 
 def run_cmake(src_dir, build_dir, extra_args=None):
     cmd = [
-        str(Path(platform.get_package_dir("tool-cmake") or "") / "bin" / "cmake"),
+        str(Path(platform.get_package_dir("tool-cmake")) / "bin" / "cmake"),
         "-S",
         src_dir,
         "-B",

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -112,7 +112,8 @@ if "arduino" in env.subst("$PIOFRAMEWORK"):
         arduino_pkg_dir = new_dir
     ARDUINO_FRAMEWORK_DIR_PATH = arduino_pkg_dir.resolve()
     ARDUINO_FRAMEWORK_DIR = str(ARDUINO_FRAMEWORK_DIR_PATH)
-    assert ARDUINO_FRAMEWORK_DIR and os.path.isdir(ARDUINO_FRAMEWORK_DIR)
+    if not ARDUINO_FRAMEWORK_DIR or not os.path.isdir(ARDUINO_FRAMEWORK_DIR):
+        raise RuntimeError(f"Arduino framework directory not found: {ARDUINO_FRAMEWORK_DIR}")
     arduino_libs_mcu = str(ARDUINO_FRAMEWORK_DIR_PATH / "tools" / "esp32-arduino-libs" / mcu)
 
 BUILD_DIR = env.subst("$BUILD_DIR")

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -120,7 +120,8 @@ if "arduino" in env.subst("$PIOFRAMEWORK"):
     ARDUINO_FRAMEWORK_DIR_PATH = arduino_pkg_dir.resolve()
     ARDUINO_FRAMEWORK_DIR = str(ARDUINO_FRAMEWORK_DIR_PATH)
     if not ARDUINO_FRAMEWORK_DIR or not os.path.isdir(ARDUINO_FRAMEWORK_DIR):
-        raise RuntimeError(f"Arduino framework directory not found: {ARDUINO_FRAMEWORK_DIR}")
+        sys.stderr.write(f"Error: Arduino framework directory not found: {ARDUINO_FRAMEWORK_DIR}\n")
+        env.Exit(1)
     arduino_libs_mcu = str(ARDUINO_FRAMEWORK_DIR_PATH / "tools" / "esp32-arduino-libs" / mcu)
 
 BUILD_DIR = env.subst("$BUILD_DIR")
@@ -2095,7 +2096,7 @@ if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PI
             try:
                 shutil.copy(str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml.orig"), str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml"))
                 print("*** Original Arduino \"idf_component.yml\" restored ***")
-            except:
+            except (FileNotFoundError, PermissionError, OSError):
                 print("*** Original Arduino \"idf_component.yml\" couldnt be restored ***")
             # Restore original pioarduino-build.py
             from component_manager import ComponentManager

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -493,6 +493,7 @@ def get_cmake_code_model(src_dir, build_dir, extra_args=None):
         if target.startswith("codemodel-v2"):
             with open(str(Path(cmake_api_reply_dir) / target), "r") as fp:
                 codemodel = json.load(fp)
+            break
 
     assert codemodel["version"]["major"] == 2
     return codemodel

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -78,11 +78,6 @@ flag_custom_sdkonfig = False
 flag_custom_component_add = False
 flag_custom_component_remove = False
 
-IDF5 = (
-    platform.get_package_version("framework-espidf")
-    .split(".")[1]
-    .startswith("5")
-)
 IDF_ENV_VERSION = "1.0.0"
 FRAMEWORK_DIR_PATH = Path(platform.get_package_dir("framework-espidf")).resolve()
 FRAMEWORK_DIR = str(FRAMEWORK_DIR_PATH)
@@ -270,8 +265,6 @@ def HandleArduinoIDFsettings(env):
             # Write checksum header (critical for compilation decision logic)
             dst.write(f"# TASMOTA__{checksum}\n")
             
-            processed_flags = set()
-            
             # Process each line from source sdkconfig
             for line in src:
                 flag_name = extract_flag_name(line)
@@ -290,7 +283,6 @@ def HandleArduinoIDFsettings(env):
                         dst.write(cleaned_flag + "\n")
                         print(f"Replace: {line.strip()} with: {cleaned_flag}")
                         idf_config_flags.remove(custom_flag)
-                        processed_flags.add(custom_flag_name)
                         flag_replaced = True
                         break
                 
@@ -391,7 +383,7 @@ def is_cmake_reconfigure_required(cmake_api_reply_dir):
         str(Path(PROJECT_SRC_DIR) / "CMakeLists.txt"),
     ]
     cmake_preconf_dir = str(Path(BUILD_DIR) / "config")
-    deafult_sdk_config = str(Path(PROJECT_DIR) / "sdkconfig.defaults")
+    default_sdk_config = str(Path(PROJECT_DIR) / "sdkconfig.defaults")
     idf_deps_lock = str(Path(PROJECT_DIR) / "dependencies.lock")
     ninja_buildfile = str(Path(BUILD_DIR) / "build.ninja")
 
@@ -406,8 +398,8 @@ def is_cmake_reconfigure_required(cmake_api_reply_dir):
         SDKCONFIG_PATH
     ) > os.path.getmtime(cmake_cache_file):
         return True
-    if os.path.isfile(deafult_sdk_config) and os.path.getmtime(
-        deafult_sdk_config
+    if os.path.isfile(default_sdk_config) and os.path.getmtime(
+        default_sdk_config
     ) > os.path.getmtime(cmake_cache_file):
         return True
     if os.path.isfile(idf_deps_lock) and os.path.getmtime(

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1913,14 +1913,15 @@ env.Prepend(
 # Propagate Arduino defines to the main build environment
 #
 
-arduino_candidates = [n for n in target_configs if n.startswith("__idf_framework-arduinoespressif32")]
-if arduino_candidates:
-    arduino_config_name = arduino_candidates[0]
-    env.AppendUnique(
-        CPPDEFINES=extract_defines(
-            target_configs.get(arduino_config_name, {}).get("compileGroups", [])[0]
+if "arduino" in env.subst("$PIOFRAMEWORK"):
+    arduino_candidates = [n for n in target_configs if n.startswith("__idf_framework-arduinoespressif32")]
+    if arduino_candidates:
+        arduino_config_name = arduino_candidates[0]
+        env.AppendUnique(
+            CPPDEFINES=extract_defines(
+                target_configs.get(arduino_config_name, {}).get("compileGroups", [])[0]
+            )
         )
-    )
 
 # Project files should be compiled only when a special
 # option is enabled when running 'test' command

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1424,7 +1424,7 @@ def generate_mbedtls_bundle(sdk_config):
         env.VerboseAction(
             " ".join(
                 [
-                    CMAKE_EXE,
+                    CMAKE_DIR,
                     "-DDATA_FILE=" + bundle_path,
                     "-DSOURCE_FILE=%s.S" % bundle_path,
                     "-DFILE_TYPE=BINARY",

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -93,9 +93,6 @@ TOOLCHAIN_DIR = platform.get_package_dir(
 )
 PLATFORMIO_DIR = env.subst("$PROJECT_CORE_DIR")
 
-if not os.path.isdir(FRAMEWORK_DIR):
-    sys.stderr.write(f"Error: Missing framework directory '{FRAMEWORK_DIR}'\n")
-    env.Exit(1)
 if not TOOLCHAIN_DIR or not os.path.isdir(TOOLCHAIN_DIR):
     sys.stderr.write(f"Error: Missing toolchain directory '{TOOLCHAIN_DIR}'\n")
     env.Exit(1)
@@ -115,8 +112,11 @@ if "arduino" in env.subst("$PIOFRAMEWORK"):
     arduino_pkg_dir = Path(_arduino_pkg_dir)
     if "@" in arduino_pkg_dir.name:
         new_dir = arduino_pkg_dir.with_name(arduino_pkg_dir.name.replace("@", "-"))
-        os.rename(str(arduino_pkg_dir), str(new_dir))
-        arduino_pkg_dir = new_dir
+        if new_dir.exists():
+            arduino_pkg_dir = new_dir
+        else:
+            os.rename(str(arduino_pkg_dir), str(new_dir))
+            arduino_pkg_dir = new_dir
     ARDUINO_FRAMEWORK_DIR_PATH = arduino_pkg_dir.resolve()
     ARDUINO_FRAMEWORK_DIR = str(ARDUINO_FRAMEWORK_DIR_PATH)
     if not ARDUINO_FRAMEWORK_DIR or not os.path.isdir(ARDUINO_FRAMEWORK_DIR):
@@ -1033,13 +1033,20 @@ def run_tool(cmd):
         print(result["err"])
 
 
+CMK_DIR = platform.get_package_dir("tool-cmake")
+if not CMK_DIR or not os.path.isdir(CMK_DIR):
+    sys.stderr.write(f"Error: Missing CMake package directory '{CMK_DIR}'\n")
+    env.Exit(1)
+CMAKE_EXE = str(Path(CMK_DIR) / "bin" / "cmake")
+
+
 def RunMenuconfig(target, source, env):
     idf_env = os.environ.copy()
     populate_idf_env_vars(idf_env)
 
     rc = subprocess.call(
         [
-            str(Path(platform.get_package_dir("tool-cmake")) / "bin" / "cmake"),
+            CMAKE_EXE,
             "--build",
             BUILD_DIR,
             "--target",
@@ -1055,7 +1062,7 @@ def RunMenuconfig(target, source, env):
 
 def run_cmake(src_dir, build_dir, extra_args=None):
     cmd = [
-        str(Path(platform.get_package_dir("tool-cmake")) / "bin" / "cmake"),
+        CMAKE_EXE,
         "-S",
         src_dir,
         "-B",
@@ -1828,7 +1835,7 @@ try:
     ld_index = extra_flags.index("memory.ld")
     extra_flags.pop(ld_index)
     extra_flags.pop(ld_index - 1)
-except:
+except (ValueError, IndexError):
     print("Warning! Couldn't find the main linker script in the CMake code model.")
 
 #
@@ -1843,9 +1850,10 @@ def _skip_prj_source_files(node):
     node_path_resolved = Path(node.srcnode().get_path()).resolve()
     try:
         node_path_resolved.relative_to(project_src_resolved)
-        return None
     except ValueError:
         return node
+    else:
+        return None
 
 
 env.AddBuildMiddleware(_skip_prj_source_files)

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2100,9 +2100,11 @@ if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PI
 if "espidf" in env.subst("$PIOFRAMEWORK") and (flag_custom_component_add == True or flag_custom_component_remove == True):
     def idf_custom_component(source, target, env):
         try:
-            shutil.copy(str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml.orig"),
-                        str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml"))
-            print("*** Original Arduino \"idf_component.yml\" restored ***")
+            # Add this check before using ARDUINO_FRAMEWORK_DIR
+            if "arduino" in env.subst("$PIOFRAMEWORK"):
+                shutil.copy(str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml.orig"),
+                            str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml"))
+                print("*** Original Arduino \"idf_component.yml\" restored ***")
         except (FileNotFoundError, PermissionError, OSError):
             try:
                 shutil.copy(str(Path(PROJECT_SRC_DIR) / "idf_component.yml.orig"), str(Path(PROJECT_SRC_DIR) / "idf_component.yml"))

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -32,6 +32,7 @@ import re
 import requests
 import platform as sys_platform
 from pathlib import Path
+from urllib.parse import urlsplit, unquote
 
 import click
 import semantic_version
@@ -121,16 +122,10 @@ SDKCONFIG_PATH = os.path.expandvars(board.get(
 ))
 
 def contains_path_traversal(url):
-    """Check for Path Traversal patterns"""
-    dangerous_patterns = [
-        '../', '..\\',  # Standard Path Traversal
-        '%2e%2e%2f', '%2e%2e%5c',  # URL-encoded
-        '..%2f', '..%5c',  # Mixed
-        '%252e%252e%252f',  # Double encoded
-    ]
-    
-    url_lower = url.lower()
-    return any(pattern in url_lower for pattern in dangerous_patterns)
+    """Best-effort detection of path traversal sequences."""
+    path = unquote(unquote(urlsplit(url).path)).replace("\\", "/")
+    parts = [p for p in path.split("/") if p not in ("", ".")]
+    return any(p == ".." for p in parts)
 
 #
 # generate modified Arduino IDF sdkconfig, applying settings from "custom_sdkconfig"
@@ -709,7 +704,7 @@ def get_sdk_configuration():
     try:
         with open(config_path, "r") as fp:
             return json.load(fp)
-    except:
+    except (OSError, json.JSONDecodeError):
         return {}
 
 
@@ -1569,10 +1564,9 @@ def ensure_python_venv_available():
 
         # Verify that the venv was created successfully by checking for Python executable
         python_path = get_executable_path(venv_dir, "python")
-        
-        assert os.path.isfile(
-            python_path
-        ), "Error: Failed to create a proper virtual environment. Missing the Python executable!"
+        if not os.path.isfile(python_path):
+            sys.stderr.write("Error: Failed to create a proper virtual environment. Missing the Python executable!\n")
+            env.Exit(1)
 
     venv_dir = get_idf_venv_dir()
     venv_data_file = str(Path(venv_dir) / "pio-idf-venv.json")

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1373,7 +1373,7 @@ def preprocess_linker_file(src_ld_script, target_ld_script):
         env.VerboseAction(
             " ".join(
                 [
-                    str(Path(platform.get_package_dir("tool-cmake")) / "bin" / "cmake"),
+                    CMAKE_EXE,
                     "-DCC=%s" % str(Path(TOOLCHAIN_DIR) / "bin" / "$CC"),
                     "-DSOURCE=$SOURCE",
                     "-DTARGET=$TARGET",
@@ -1918,12 +1918,10 @@ env.Prepend(
 if "arduino" in env.subst("$PIOFRAMEWORK"):
     arduino_candidates = [n for n in target_configs if n.startswith("__idf_framework-arduinoespressif32")]
     if arduino_candidates:
-        arduino_config_name = arduino_candidates[0]
-        env.AppendUnique(
-            CPPDEFINES=extract_defines(
-                target_configs.get(arduino_config_name, {}).get("compileGroups", [])[0]
-            )
-        )
+        arduino_cfg = target_configs.get(arduino_candidates[0], {})
+        cg_list = arduino_cfg.get("compileGroups", [])
+        if cg_list:
+            env.AppendUnique(CPPDEFINES=extract_defines(cg_list[0]))
 
 # Project files should be compiled only when a special
 # option is enabled when running 'test' command

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -264,6 +264,9 @@ def HandleArduinoIDFsettings(env):
         """Write the final sdkconfig.defaults file with checksum."""
         sdkconfig_src = str(Path(ARDUINO_FRAMEWORK_DIR) / "tools" / "esp32-arduino-libs" / mcu / "sdkconfig")
         sdkconfig_dst = str(Path(PROJECT_DIR) / "sdkconfig.defaults")
+        if not os.path.isfile(sdkconfig_src):
+            sys.stderr.write(f"Error: Missing Arduino sdkconfig template at '{sdkconfig_src}'\n")
+            env.Exit(1)
         
         # Generate checksum for validation (maintains original logic)
         checksum = get_MD5_hash(checksum_source.strip() + mcu)

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -104,16 +104,16 @@ def create_silent_action(action_func):
     return silent_action
 
 if "arduino" in env.subst("$PIOFRAMEWORK"):
-    ARDUINO_FRAMEWORK_DIR_PATH = Path(platform.get_package_dir("framework-arduinoespressif32")).resolve()
+    arduino_pkg_dir = Path(platform.get_package_dir("framework-arduinoespressif32"))
+    # Rename using the symlink path (do not resolve before rename)
+    if "@" in arduino_pkg_dir.name:
+        new_dir = arduino_pkg_dir.with_name(arduino_pkg_dir.name.replace("@", "-"))
+        os.rename(str(arduino_pkg_dir), str(new_dir))
+        arduino_pkg_dir = new_dir
+    ARDUINO_FRAMEWORK_DIR_PATH = arduino_pkg_dir.resolve()
     ARDUINO_FRAMEWORK_DIR = str(ARDUINO_FRAMEWORK_DIR_PATH)
-    # Possible package names in 'package@version' format is not compatible with CMake
-    if "@" in os.path.basename(ARDUINO_FRAMEWORK_DIR):
-        new_path = str(Path(os.path.dirname(ARDUINO_FRAMEWORK_DIR)) / 
-                      os.path.basename(ARDUINO_FRAMEWORK_DIR).replace("@", "-"))
-        os.rename(ARDUINO_FRAMEWORK_DIR, new_path)
-        ARDUINO_FRAMEWORK_DIR = new_path
     assert ARDUINO_FRAMEWORK_DIR and os.path.isdir(ARDUINO_FRAMEWORK_DIR)
-    arduino_libs_mcu = str(Path(ARDUINO_FRAMEWORK_DIR) / "tools" / "esp32-arduino-libs" / mcu)
+    arduino_libs_mcu = str(ARDUINO_FRAMEWORK_DIR_PATH / "tools" / "esp32-arduino-libs" / mcu)
 
 BUILD_DIR = env.subst("$BUILD_DIR")
 PROJECT_DIR = env.subst("$PROJECT_DIR")
@@ -981,8 +981,8 @@ def compile_source_files(
     build_envs = prepare_build_envs(config, default_env, debug_allowed)
     objects = []
     # Canonical, symlink-resolved absolute path of the components directory
-    components_dir_path = Path(FRAMEWORK_DIR) / "components"
-    components_dir = str(components_dir_path.resolve())
+    components_dir_path = (Path(FRAMEWORK_DIR) / "components").resolve()
+    components_dir = str(components_dir_path)
     for source in config.get("sources", []):
         if source["path"].endswith(".rule"):
             continue
@@ -997,9 +997,15 @@ def compile_source_files(
                 src_path = str(Path(project_src_dir) / src_path)
 
             obj_path = str(Path("$BUILD_DIR") / (prepend_dir or ""))
-            resolved_src_path = str(Path(src_path).resolve())
-            if resolved_src_path.lower().startswith(components_dir.lower()):
-                obj_path = str(Path(obj_path) / os.path.relpath(resolved_src_path, components_dir))
+            src_path_obj = Path(src_path).resolve()
+            try:
+                rel = src_path_obj.relative_to(components_dir_path)
+                obj_path = str(Path(obj_path) / str(rel))
+            except ValueError:
+                if not os.path.isabs(source["path"]):
+                    obj_path = str(Path(obj_path) / source["path"])
+                else:
+                    obj_path = str(Path(obj_path) / os.path.basename(src_path))
             else:
                 if not os.path.isabs(source["path"]):
                     obj_path = str(Path(obj_path) / source["path"])
@@ -1017,7 +1023,7 @@ def compile_source_files(
                         if preserve_source_file_extension
                         else os.path.splitext(obj_path)[0]
                     ) + ".o",
-                    source=os.path.realpath(src_path),
+                    source=str(src_path_obj),
                 )
             )
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -983,9 +983,6 @@ def compile_source_files(
             continue
         compile_group_idx = source.get("compileGroupIndex")
         if compile_group_idx is not None:
-            src_dir = config["paths"]["source"]
-            if not os.path.isabs(src_dir):
-                src_dir = str(Path(project_src_dir) / config["paths"]["source"])
             src_path = source.get("path")
             if not os.path.isabs(src_path):
                 # For cases when sources are located near CMakeLists.txt
@@ -1222,7 +1219,7 @@ idf_component_register(SRCS ${component_sources})
     if os.path.isdir(dummy_component_path):
         return
 
-    os.makedirs(dummy_component_path)
+    os.makedirs(dummy_component_path, exist_ok=True)
 
     for ext in (".cpp", ".c", ".S"):
         dummy_file = str(Path(dummy_component_path) / ("__dummy" + ext))
@@ -1591,9 +1588,9 @@ def ensure_python_venv_available():
 def get_python_exe():
     python_exe_path = str(Path(get_idf_venv_dir()) / ("Scripts" if IS_WINDOWS else "bin") / ("python" + (".exe" if IS_WINDOWS else "")))
 
-    assert os.path.isfile(python_exe_path), (
-        "Error: Missing Python executable file `%s`" % python_exe_path
-    )
+    if not os.path.isfile(python_exe_path):
+        sys.stderr.write("Error: Missing Python executable file `%s`\n" % python_exe_path)
+        env.Exit(1)
 
     return python_exe_path
 
@@ -2028,7 +2025,7 @@ if os.path.isdir(ulp_dir) and os.listdir(ulp_dir) and mcu not in ("esp32c2", "es
 #
 
 if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PIOFRAMEWORK")):
-    def idf_lib_copy(source, target, env):
+    def idf_lib_copy(_source, _target, env):
         def _replace_move(src, dst):
             dst_p = Path(dst)
             dst_p.parent.mkdir(parents=True, exist_ok=True)
@@ -2036,7 +2033,10 @@ if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PI
                 os.remove(dst)
             except FileNotFoundError:
                 pass
-            shutil.move(src, dst)
+            try:
+                os.replace(src, dst)
+            except OSError:
+                shutil.move(src, dst)
         env_build = str(Path(env["PROJECT_BUILD_DIR"]) / env["PIOENV"])
         sdkconfig_h_path = str(Path(env_build) / "config" / "sdkconfig.h")
         arduino_libs = str(Path(ARDUINO_FRAMEWORK_DIR) / "tools" / "esp32-arduino-libs")

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -981,8 +981,8 @@ def compile_source_files(
                 src_dir = str(Path(project_src_dir) / config["paths"]["source"])
             src_path = source.get("path")
             if not os.path.isabs(src_path):
-                # For cases when sources are located near CMakeLists.txt
-                src_path = str(Path(project_src_dir) / src_path)
+                # Resolve relative to the component's source dir
+                src_path = str(Path(src_dir) / src_path)
 
             obj_path = str(Path("$BUILD_DIR") / (prepend_dir or ""))
             src_path_obj = Path(src_path).resolve()

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -53,14 +53,14 @@ env = DefaultEnvironment()
 env.SConscript("_embed_files.py", exports="env")
 platform = env.PioPlatform()
 
-_penv_setup_file = os.path.join(platform.get_dir(), "builder", "penv_setup.py")
+_penv_setup_file = str(Path(platform.get_dir()) / "builder" / "penv_setup.py")
 _spec = importlib.util.spec_from_file_location("penv_setup", _penv_setup_file)
 _penv_setup = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_penv_setup)  # type: ignore[attr-defined]
 get_executable_path = _penv_setup.get_executable_path
 
 # remove maybe existing old map file in project root
-map_file = os.path.join(env.subst("$PROJECT_DIR"), env.subst("$PROGNAME") + ".map")
+map_file = str(Path(env.subst("$PROJECT_DIR")) / (env.subst("$PROGNAME") + ".map"))
 if os.path.exists(map_file):
     os.remove(map_file)
 
@@ -108,22 +108,20 @@ if "arduino" in env.subst("$PIOFRAMEWORK"):
     ARDUINO_FRAMEWORK_DIR = str(ARDUINO_FRAMEWORK_DIR_PATH)
     # Possible package names in 'package@version' format is not compatible with CMake
     if "@" in os.path.basename(ARDUINO_FRAMEWORK_DIR):
-        new_path = os.path.join(
-            os.path.dirname(ARDUINO_FRAMEWORK_DIR),
-            os.path.basename(ARDUINO_FRAMEWORK_DIR).replace("@", "-"),
-        )
+        new_path = str(Path(os.path.dirname(ARDUINO_FRAMEWORK_DIR)) / 
+                      os.path.basename(ARDUINO_FRAMEWORK_DIR).replace("@", "-"))
         os.rename(ARDUINO_FRAMEWORK_DIR, new_path)
         ARDUINO_FRAMEWORK_DIR = new_path
     assert ARDUINO_FRAMEWORK_DIR and os.path.isdir(ARDUINO_FRAMEWORK_DIR)
-    arduino_libs_mcu = join(ARDUINO_FRAMEWORK_DIR,"tools","esp32-arduino-libs",mcu)
+    arduino_libs_mcu = str(Path(ARDUINO_FRAMEWORK_DIR) / "tools" / "esp32-arduino-libs" / mcu)
 
 BUILD_DIR = env.subst("$BUILD_DIR")
 PROJECT_DIR = env.subst("$PROJECT_DIR")
 PROJECT_SRC_DIR = env.subst("$PROJECT_SRC_DIR")
-CMAKE_API_REPLY_PATH = os.path.join(".cmake", "api", "v1", "reply")
+CMAKE_API_REPLY_PATH = str(Path(".cmake") / "api" / "v1" / "reply")
 SDKCONFIG_PATH = os.path.expandvars(board.get(
         "build.esp-idf.sdkconfig_path",
-        os.path.join(PROJECT_DIR, "sdkconfig.%s" % env.subst("$PIOENV")),
+        str(Path(PROJECT_DIR) / ("sdkconfig.%s" % env.subst("$PIOENV"))),
 ))
 
 def contains_path_traversal(url):
@@ -190,7 +188,7 @@ def HandleArduinoIDFsettings(env):
             if "file://" in file_entry:
                 file_ref = file_entry[7:] if file_entry.startswith("file://") else file_entry
                 filename = os.path.basename(file_ref)
-                file_path = join(PROJECT_DIR, filename)
+                file_path = str(Path(PROJECT_DIR) / filename)
                 if os.path.exists(file_path):
                     try:
                         with open(file_path, 'r') as f:
@@ -261,8 +259,8 @@ def HandleArduinoIDFsettings(env):
             print("Error: Arduino framework required for sdkconfig processing")
             return
         """Write the final sdkconfig.defaults file with checksum."""
-        sdkconfig_src = join(ARDUINO_FRAMEWORK_DIR, "tools", "esp32-arduino-libs", mcu, "sdkconfig")
-        sdkconfig_dst = join(PROJECT_DIR, "sdkconfig.defaults")
+        sdkconfig_src = str(Path(ARDUINO_FRAMEWORK_DIR) / "tools" / "esp32-arduino-libs" / mcu / "sdkconfig")
+        sdkconfig_dst = str(Path(PROJECT_DIR) / "sdkconfig.defaults")
         
         # Generate checksum for validation (maintains original logic)
         checksum = get_MD5_hash(checksum_source.strip() + mcu)
@@ -355,10 +353,10 @@ if "arduino" in env.subst("$PIOFRAMEWORK"):
 
 if flag_custom_sdkonfig == True and "arduino" in env.subst("$PIOFRAMEWORK") and "espidf" not in env.subst("$PIOFRAMEWORK"):
     HandleArduinoIDFsettings(env)
-    LIB_SOURCE = os.path.join(platform.get_dir(), "builder", "build_lib")
-    if not bool(os.path.exists(os.path.join(PROJECT_DIR, ".dummy"))):
-        shutil.copytree(LIB_SOURCE, os.path.join(PROJECT_DIR, ".dummy"))
-    PROJECT_SRC_DIR = os.path.join(PROJECT_DIR, ".dummy")
+    LIB_SOURCE = str(Path(platform.get_dir()) / "builder" / "build_lib")
+    if not bool(os.path.exists(str(Path(PROJECT_DIR) / ".dummy"))):
+        shutil.copytree(LIB_SOURCE, str(Path(PROJECT_DIR) / ".dummy"))
+    PROJECT_SRC_DIR = str(Path(PROJECT_DIR) / ".dummy")
     env.Replace(
         PROJECT_SRC_DIR=PROJECT_SRC_DIR,
         BUILD_FLAGS="",
@@ -386,15 +384,15 @@ def get_project_lib_includes(env):
     return paths
 
 def is_cmake_reconfigure_required(cmake_api_reply_dir):
-    cmake_cache_file = os.path.join(BUILD_DIR, "CMakeCache.txt")
+    cmake_cache_file = str(Path(BUILD_DIR) / "CMakeCache.txt")
     cmake_txt_files = [
-        os.path.join(PROJECT_DIR, "CMakeLists.txt"),
-        os.path.join(PROJECT_SRC_DIR, "CMakeLists.txt"),
+        str(Path(PROJECT_DIR) / "CMakeLists.txt"),
+        str(Path(PROJECT_SRC_DIR) / "CMakeLists.txt"),
     ]
-    cmake_preconf_dir = os.path.join(BUILD_DIR, "config")
-    deafult_sdk_config = os.path.join(PROJECT_DIR, "sdkconfig.defaults")
-    idf_deps_lock = os.path.join(PROJECT_DIR, "dependencies.lock")
-    ninja_buildfile = os.path.join(BUILD_DIR, "build.ninja")
+    cmake_preconf_dir = str(Path(BUILD_DIR) / "config")
+    deafult_sdk_config = str(Path(PROJECT_DIR) / "sdkconfig.defaults")
+    idf_deps_lock = str(Path(PROJECT_DIR) / "dependencies.lock")
+    ninja_buildfile = str(Path(BUILD_DIR) / "build.ninja")
 
     for d in (cmake_api_reply_dir, cmake_preconf_dir):
         if not os.path.isdir(d) or not os.listdir(d):
@@ -428,8 +426,8 @@ def is_proper_idf_project():
     return all(
         os.path.isfile(path)
         for path in (
-            os.path.join(PROJECT_DIR, "CMakeLists.txt"),
-            os.path.join(PROJECT_SRC_DIR, "CMakeLists.txt"),
+            str(Path(PROJECT_DIR) / "CMakeLists.txt"),
+            str(Path(PROJECT_SRC_DIR) / "CMakeLists.txt"),
         )
     )
 
@@ -463,25 +461,25 @@ idf_component_register(SRCS ${app_sources})
 
     if not os.listdir(PROJECT_SRC_DIR):
         # create a default main file to make CMake happy during first init
-        with open(os.path.join(PROJECT_SRC_DIR, "main.c"), "w") as fp:
+        with open(str(Path(PROJECT_SRC_DIR) / "main.c"), "w") as fp:
             fp.write("void app_main() {}")
 
     project_dir = PROJECT_DIR
-    if not os.path.isfile(os.path.join(project_dir, "CMakeLists.txt")):
-        with open(os.path.join(project_dir, "CMakeLists.txt"), "w") as fp:
+    if not os.path.isfile(str(Path(project_dir) / "CMakeLists.txt")):
+        with open(str(Path(project_dir) / "CMakeLists.txt"), "w") as fp:
             fp.write(root_cmake_tpl % os.path.basename(project_dir))
 
     project_src_dir = PROJECT_SRC_DIR
-    if not os.path.isfile(os.path.join(project_src_dir, "CMakeLists.txt")):
-        with open(os.path.join(project_src_dir, "CMakeLists.txt"), "w") as fp:
+    if not os.path.isfile(str(Path(project_src_dir) / "CMakeLists.txt")):
+        with open(str(Path(project_src_dir) / "CMakeLists.txt"), "w") as fp:
             fp.write(prj_cmake_tpl % normalize_path(PROJECT_SRC_DIR))
 
 
 def get_cmake_code_model(src_dir, build_dir, extra_args=None):
-    cmake_api_dir = os.path.join(build_dir, ".cmake", "api", "v1")
-    cmake_api_query_dir = os.path.join(cmake_api_dir, "query")
-    cmake_api_reply_dir = os.path.join(cmake_api_dir, "reply")
-    query_file = os.path.join(cmake_api_query_dir, "codemodel-v2")
+    cmake_api_dir = str(Path(build_dir) / ".cmake" / "api" / "v1")
+    cmake_api_query_dir = str(Path(cmake_api_dir) / "query")
+    cmake_api_reply_dir = str(Path(cmake_api_dir) / "reply")
+    query_file = str(Path(cmake_api_query_dir) / "codemodel-v2")
 
     if not os.path.isfile(query_file):
         os.makedirs(os.path.dirname(query_file))
@@ -500,7 +498,7 @@ def get_cmake_code_model(src_dir, build_dir, extra_args=None):
     codemodel = {}
     for target in os.listdir(cmake_api_reply_dir):
         if target.startswith("codemodel-v2"):
-            with open(os.path.join(cmake_api_reply_dir, target), "r") as fp:
+            with open(str(Path(cmake_api_reply_dir) / target), "r") as fp:
                 codemodel = json.load(fp)
 
     assert codemodel["version"]["major"] == 2
@@ -510,9 +508,9 @@ def get_cmake_code_model(src_dir, build_dir, extra_args=None):
 def populate_idf_env_vars(idf_env):
     idf_env["IDF_PATH"] = fs.to_unix_path(FRAMEWORK_DIR)
     additional_packages = [
-        os.path.join(TOOLCHAIN_DIR, "bin"),
+        str(Path(TOOLCHAIN_DIR) / "bin"),
         platform.get_package_dir("tool-ninja"),
-        os.path.join(platform.get_package_dir("tool-cmake"), "bin"),
+        str(Path(platform.get_package_dir("tool-cmake")) / "bin"),
         os.path.dirname(get_python_exe()),
     ]
 
@@ -528,7 +526,7 @@ def populate_idf_env_vars(idf_env):
 
 def get_target_config(project_configs, target_index, cmake_api_reply_dir):
     target_json = project_configs.get("targets")[target_index].get("jsonFile", "")
-    target_config_file = os.path.join(cmake_api_reply_dir, target_json)
+    target_config_file = str(Path(cmake_api_reply_dir) / target_json)
     if not os.path.isfile(target_config_file):
         sys.stderr.write("Error: Couldn't find target config %s\n" % target_json)
         env.Exit(1)
@@ -556,12 +554,12 @@ def build_library(
     lib_name = lib_config["nameOnDisk"]
     lib_path = lib_config["paths"]["build"]
     if prepend_dir:
-        lib_path = os.path.join(prepend_dir, lib_path)
+        lib_path = str(Path(prepend_dir) / lib_path)
     lib_objects = compile_source_files(
         lib_config, default_env, project_src_dir, prepend_dir, debug_allowed
     )
     return default_env.Library(
-        target=os.path.join("$BUILD_DIR", lib_path, lib_name), source=lib_objects
+        target=str(Path("$BUILD_DIR") / lib_path / lib_name), source=lib_objects
     )
 
 
@@ -653,7 +651,7 @@ def extract_link_args(target_config):
                     if archive_path.startswith(".."):
                         # Precompiled archives from project component
                         _add_archive(
-                            os.path.normpath(os.path.join(BUILD_DIR, archive_path)),
+                            os.path.normpath(str(Path(BUILD_DIR) / archive_path)),
                             link_args,
                         )
                     else:
@@ -710,7 +708,7 @@ def get_app_flags(app_config, default_config):
 
 
 def get_sdk_configuration():
-    config_path = os.path.join(BUILD_DIR, "config", "sdkconfig.json")
+    config_path = str(Path(BUILD_DIR) / "config" / "sdkconfig.json")
     if not os.path.isfile(config_path):
         print('Warning: Could not find "sdkconfig.json" file\n')
 
@@ -725,7 +723,7 @@ def load_component_paths(framework_components_dir, ignored_component_prefixes=No
     def _scan_components_from_framework():
         result = []
         for component in os.listdir(framework_components_dir):
-            component_path = os.path.join(framework_components_dir, component)
+            component_path = str(Path(framework_components_dir) / component)
             if component.startswith(ignored_component_prefixes) or not os.path.isdir(
                 component_path
             ):
@@ -737,7 +735,7 @@ def load_component_paths(framework_components_dir, ignored_component_prefixes=No
     # First of all, try to load the list of used components from the project description
     components = []
     ignored_component_prefixes = ignored_component_prefixes or []
-    project_description_file = os.path.join(BUILD_DIR, "project_description.json")
+    project_description_file = str(Path(BUILD_DIR) / "project_description.json")
     if os.path.isfile(project_description_file):
         with open(project_description_file) as fp:
             try:
@@ -763,7 +761,7 @@ def extract_linker_script_fragments_backup(framework_components_dir, sdk_config)
 
     result = []
     for component_path in project_components:
-        linker_fragment = os.path.join(component_path, "linker.lf")
+        linker_fragment = str(Path(component_path) / "linker.lf")
         if os.path.isfile(linker_fragment):
             result.append(linker_fragment)
 
@@ -772,29 +770,27 @@ def extract_linker_script_fragments_backup(framework_components_dir, sdk_config)
         env.Exit(1)
 
     if mcu not in ("esp32", "esp32s2", "esp32s3"):
-        result.append(os.path.join(framework_components_dir, "riscv", "linker.lf"))
+        result.append(str(Path(framework_components_dir) / "riscv" / "linker.lf"))
 
     # Add extra linker fragments
     for fragment in (
-        os.path.join("esp_system", "app.lf"),
-        os.path.join("esp_common", "common.lf"),
-        os.path.join("esp_common", "soc.lf"),
-        os.path.join("newlib", "system_libs.lf"),
-        os.path.join("newlib", "newlib.lf"),
+        str(Path("esp_system") / "app.lf"),
+        str(Path("esp_common") / "common.lf"),
+        str(Path("esp_common") / "soc.lf"),
+        str(Path("newlib") / "system_libs.lf"),
+        str(Path("newlib") / "newlib.lf"),
     ):
-        result.append(os.path.join(framework_components_dir, fragment))
+        result.append(str(Path(framework_components_dir) / fragment))
 
     if sdk_config.get("SPIRAM_CACHE_WORKAROUND", False):
         result.append(
-            os.path.join(
-                framework_components_dir, "newlib", "esp32-spiram-rom-functions-c.lf"
-            )
+            str(Path(framework_components_dir) / "newlib" / "esp32-spiram-rom-functions-c.lf")
         )
 
     if board.get("build.esp-idf.extra_lf_files", ""):
         result.extend(
             [
-                lf if os.path.isabs(lf) else os.path.join(PROJECT_DIR, lf)
+                lf if os.path.isabs(lf) else str(Path(PROJECT_DIR) / lf)
                 for lf in board.get("build.esp-idf.extra_lf_files").splitlines()
                 if lf.strip()
             ]
@@ -809,7 +805,7 @@ def extract_linker_script_fragments(
     def _normalize_fragment_path(base_dir, fragment_path):
         if not os.path.isabs(fragment_path):
             fragment_path = os.path.abspath(
-                os.path.join(base_dir, fragment_path)
+                str(Path(base_dir) / fragment_path)
             )
         if not os.path.isfile(fragment_path):
             print("Warning! The `%s` fragment is not found!" % fragment_path)
@@ -877,31 +873,27 @@ def create_custom_libraries_list(ldgen_libraries_file, ignore_targets):
 def generate_project_ld_script(sdk_config, ignore_targets=None):
     ignore_targets = ignore_targets or []
     linker_script_fragments = extract_linker_script_fragments(
-        os.path.join(BUILD_DIR, "build.ninja"),
-        os.path.join(FRAMEWORK_DIR, "components"),
+        str(Path(BUILD_DIR) / "build.ninja"),
+        str(Path(FRAMEWORK_DIR) / "components"),
         sdk_config
     )
 
     # Create a new file to avoid automatically generated library entry as files
     # from this library are built internally by PlatformIO
     libraries_list = create_custom_libraries_list(
-        os.path.join(BUILD_DIR, "ldgen_libraries"), ignore_targets
+        str(Path(BUILD_DIR) / "ldgen_libraries"), ignore_targets
     )
 
     args = {
-        "script": os.path.join(FRAMEWORK_DIR, "tools", "ldgen", "ldgen.py"),
+        "script": str(Path(FRAMEWORK_DIR) / "tools" / "ldgen" / "ldgen.py"),
         "config": SDKCONFIG_PATH,
         "fragments": " ".join(
             ['"%s"' % fs.to_unix_path(f) for f in linker_script_fragments]
         ),
-        "kconfig": os.path.join(FRAMEWORK_DIR, "Kconfig"),
-        "env_file": os.path.join("$BUILD_DIR", "config.env"),
+        "kconfig": str(Path(FRAMEWORK_DIR) / "Kconfig"),
+        "env_file": str(Path("$BUILD_DIR") / "config.env"),
         "libraries_list": libraries_list,
-        "objdump": os.path.join(
-            TOOLCHAIN_DIR,
-            "bin",
-            env.subst("$CC").replace("-gcc", "-objdump"),
-        ),
+        "objdump": str(Path(TOOLCHAIN_DIR) / "bin" / env.subst("$CC").replace("-gcc", "-objdump")),
     }
 
     cmd = (
@@ -912,30 +904,17 @@ def generate_project_ld_script(sdk_config, ignore_targets=None):
         '--objdump "{objdump}"'
     ).format(**args)
 
-    initial_ld_script = os.path.join(
-        FRAMEWORK_DIR,
-        "components",
-        "esp_system",
-        "ld",
-        idf_variant,
-        "sections.ld.in",
-    )
+    initial_ld_script = str(Path(FRAMEWORK_DIR) / "components" / "esp_system" / "ld" / idf_variant / "sections.ld.in")
 
     framework_version = [int(v) for v in get_framework_version().split(".")]
     if framework_version[:2] > [5, 2]:
         initial_ld_script = preprocess_linker_file(
             initial_ld_script,
-            os.path.join(
-                BUILD_DIR,
-                "esp-idf",
-                "esp_system",
-                "ld",
-                "sections.ld.in",
-            )
+            str(Path(BUILD_DIR) / "esp-idf" / "esp_system" / "ld" / "sections.ld.in"),
         )
 
     return env.Command(
-        os.path.join("$BUILD_DIR", "sections.ld"),
+        str(Path("$BUILD_DIR") / "sections.ld"),
         initial_ld_script,
         env.VerboseAction(cmd, "Generating project linker script $TARGET"),
     )
@@ -1002,8 +981,8 @@ def compile_source_files(
     build_envs = prepare_build_envs(config, default_env, debug_allowed)
     objects = []
     # Canonical, symlink-resolved absolute path of the components directory
-    components_dir_path = Path(FRAMEWORK_DIR, "components").resolve()
-    components_dir = str(components_dir_path)
+    components_dir_path = Path(FRAMEWORK_DIR) / "components"
+    components_dir = str(components_dir_path.resolve())
     for source in config.get("sources", []):
         if source["path"].endswith(".rule"):
             continue
@@ -1011,23 +990,21 @@ def compile_source_files(
         if compile_group_idx is not None:
             src_dir = config["paths"]["source"]
             if not os.path.isabs(src_dir):
-                src_dir = os.path.join(project_src_dir, config["paths"]["source"])
+                src_dir = str(Path(project_src_dir) / config["paths"]["source"])
             src_path = source.get("path")
             if not os.path.isabs(src_path):
                 # For cases when sources are located near CMakeLists.txt
-                src_path = os.path.join(project_src_dir, src_path)
+                src_path = str(Path(project_src_dir) / src_path)
 
-            obj_path = os.path.join("$BUILD_DIR", prepend_dir or "")
+            obj_path = str(Path("$BUILD_DIR") / (prepend_dir or ""))
             resolved_src_path = str(Path(src_path).resolve())
             if resolved_src_path.lower().startswith(components_dir.lower()):
-                obj_path = os.path.join(
-                    obj_path, os.path.relpath(resolved_src_path, components_dir)
-                )
+                obj_path = str(Path(obj_path) / os.path.relpath(resolved_src_path, components_dir))
             else:
                 if not os.path.isabs(source["path"]):
-                    obj_path = os.path.join(obj_path, source["path"])
+                    obj_path = str(Path(obj_path) / source["path"])
                 else:
-                    obj_path = os.path.join(obj_path, os.path.basename(src_path))
+                    obj_path = str(Path(obj_path) / os.path.basename(src_path))
 
             preserve_source_file_extension = board.get(
                 "build.esp-idf.preserve_source_file_extension", "yes"
@@ -1068,7 +1045,7 @@ def RunMenuconfig(target, source, env):
 
     rc = subprocess.call(
         [
-            os.path.join(platform.get_package_dir("tool-cmake"), "bin", "cmake"),
+            str(Path(platform.get_package_dir("tool-cmake")) / "bin" / "cmake"),
             "--build",
             BUILD_DIR,
             "--target",
@@ -1084,7 +1061,7 @@ def RunMenuconfig(target, source, env):
 
 def run_cmake(src_dir, build_dir, extra_args=None):
     cmd = [
-        os.path.join(platform.get_package_dir("tool-cmake") or "", "bin", "cmake"),
+        str(Path(platform.get_package_dir("tool-cmake") or "") / "bin" / "cmake"),
         "-S",
         src_dir,
         "-B",
@@ -1126,12 +1103,10 @@ def find_lib_deps(components_map, elf_config, link_args, ignore_components=None)
 
 
 def build_bootloader(sdk_config):
-    bootloader_src_dir = os.path.join(
-        FRAMEWORK_DIR, "components", "bootloader", "subproject"
-    )
+    bootloader_src_dir = str(Path(FRAMEWORK_DIR) / "components" / "bootloader" / "subproject")
     code_model = get_cmake_code_model(
         bootloader_src_dir,
-        os.path.join(BUILD_DIR, "bootloader"),
+        str(Path(BUILD_DIR) / "bootloader"),
         [
             "-DIDF_TARGET=" + idf_variant,
             "-DPYTHON_DEPS_CHECKED=1",
@@ -1140,8 +1115,7 @@ def build_bootloader(sdk_config):
             "-DSDKCONFIG=" + SDKCONFIG_PATH,
             "-DPROJECT_SOURCE_DIR=" + PROJECT_DIR,
             "-DLEGACY_INCLUDE_COMMON_HEADERS=",
-            "-DEXTRA_COMPONENT_DIRS="
-            + os.path.join(FRAMEWORK_DIR, "components", "bootloader"),
+            "-DEXTRA_COMPONENT_DIRS=" + str(Path(FRAMEWORK_DIR) / "components" / "bootloader"),
         ],
     )
 
@@ -1151,7 +1125,7 @@ def build_bootloader(sdk_config):
 
     target_configs = load_target_configurations(
         code_model,
-        os.path.join(BUILD_DIR, "bootloader", ".cmake", "api", "v1", "reply"),
+        str(Path(BUILD_DIR) / "bootloader" / ".cmake" / "api" / "v1" / "reply"),
     )
 
     elf_config = get_project_elf(target_configs)
@@ -1191,9 +1165,9 @@ def build_bootloader(sdk_config):
     )
 
     return bootloader_env.ElfToBin(
-        os.path.join("$BUILD_DIR", "bootloader"),
+        str(Path("$BUILD_DIR") / "bootloader"),
         bootloader_env.Program(
-            os.path.join("$BUILD_DIR", "bootloader.elf"), bootloader_libs
+            str(Path("$BUILD_DIR") / "bootloader.elf"), bootloader_libs
         ),
     )
 
@@ -1248,18 +1222,18 @@ def generate_default_component():
 file(GLOB component_sources *.c* *.S)
 idf_component_register(SRCS ${component_sources})
 """
-    dummy_component_path = os.path.join(FRAMEWORK_DIR, "components", "__pio_env")
+    dummy_component_path = str(Path(FRAMEWORK_DIR) / "components" / "__pio_env")
     if os.path.isdir(dummy_component_path):
         return
 
     os.makedirs(dummy_component_path)
 
     for ext in (".cpp", ".c", ".S"):
-        dummy_file = os.path.join(dummy_component_path, "__dummy" + ext)
+        dummy_file = str(Path(dummy_component_path) / ("__dummy" + ext))
         if not os.path.isfile(dummy_file):
             open(dummy_file, "a").close()
 
-    component_cmake = os.path.join(dummy_component_path, "CMakeLists.txt")
+    component_cmake = str(Path(dummy_component_path) / "CMakeLists.txt")
     if not os.path.isfile(component_cmake):
         with open(component_cmake, "w") as fp:
             fp.write(prj_cmake_tpl)
@@ -1280,9 +1254,7 @@ def find_default_component(target_configs):
 
 def get_framework_version():
     def _extract_from_cmake_version_file():
-        version_cmake_file = os.path.join(
-            FRAMEWORK_DIR, "tools", "cmake", "version.cmake"
-        )
+        version_cmake_file = str(Path(FRAMEWORK_DIR) / "tools" / "cmake" / "version.cmake")
         if not os.path.isfile(version_cmake_file):
             return
 
@@ -1306,7 +1278,7 @@ def get_framework_version():
 
 
 def create_version_file():
-    version_file = os.path.join(FRAMEWORK_DIR, "version.txt")
+    version_file = str(Path(FRAMEWORK_DIR) / "version.txt")
     if not os.path.isfile(version_file):
         with open(version_file, "w") as fp:
             fp.write(get_framework_version())
@@ -1319,12 +1291,7 @@ def generate_empty_partition_image(binary_path, image_size):
         env.VerboseAction(
             '"$ESPIDF_PYTHONEXE" "%s" %s $TARGET'
             % (
-                os.path.join(
-                    FRAMEWORK_DIR,
-                    "components",
-                    "partition_table",
-                    "gen_empty_partition.py",
-                ),
+                str(Path(FRAMEWORK_DIR) / "components" / "partition_table" / "gen_empty_partition.py"),
                 image_size,
             ),
             "Generating an empty partition $TARGET",
@@ -1344,7 +1311,7 @@ def get_partition_info(pt_path, pt_offset, pt_params):
 
     cmd = [
         get_python_exe(),
-        os.path.join(FRAMEWORK_DIR, "components", "partition_table", "parttool.py"),
+        str(Path(FRAMEWORK_DIR) / "components" / "partition_table" / "parttool.py"),
         "-q",
         "--partition-table-offset",
         hex(pt_offset),
@@ -1401,32 +1368,14 @@ def preprocess_linker_file(src_ld_script, target_ld_script):
         env.VerboseAction(
             " ".join(
                 [
-                    os.path.join(
-                        platform.get_package_dir("tool-cmake"),
-                        "bin",
-                        "cmake",
-                    ),
-                    "-DCC=%s"
-                    % os.path.join(
-                        TOOLCHAIN_DIR,
-                        "bin",
-                        "$CC",
-                    ),
+                    str(Path(platform.get_package_dir("tool-cmake")) / "bin" / "cmake"),
+                    "-DCC=%s" % str(Path(TOOLCHAIN_DIR) / "bin" / "$CC"),
                     "-DSOURCE=$SOURCE",
                     "-DTARGET=$TARGET",
-                    "-DCONFIG_DIR=%s" % os.path.join(BUILD_DIR, "config"),
-                    "-DLD_DIR=%s"
-                    % os.path.join(
-                        FRAMEWORK_DIR, "components", "esp_system", "ld"
-                    ),
+                    "-DCONFIG_DIR=%s" % str(Path(BUILD_DIR) / "config"),
+                    "-DLD_DIR=%s" % str(Path(FRAMEWORK_DIR) / "components" / "esp_system" / "ld"),
                     "-P",
-                    os.path.join(
-                        "$BUILD_DIR",
-                        "esp-idf",
-                        "esp_system",
-                        "ld",
-                        "linker_script_generator.cmake",
-                    ),
+                    str(Path("$BUILD_DIR") / "esp-idf" / "esp_system" / "ld" / "linker_script_generator.cmake"),
                 ]
             ),
             "Generating LD script $TARGET",
@@ -1435,25 +1384,23 @@ def preprocess_linker_file(src_ld_script, target_ld_script):
 
 
 def generate_mbedtls_bundle(sdk_config):
-    bundle_path = os.path.join("$BUILD_DIR", "x509_crt_bundle")
+    bundle_path = str(Path("$BUILD_DIR") / "x509_crt_bundle")
     if os.path.isfile(env.subst(bundle_path)):
         return
 
-    default_crt_dir = os.path.join(
-        FRAMEWORK_DIR, "components", "mbedtls", "esp_crt_bundle"
-    )
+    default_crt_dir = str(Path(FRAMEWORK_DIR) / "components" / "mbedtls" / "esp_crt_bundle")
 
-    cmd = [get_python_exe(), os.path.join(default_crt_dir, "gen_crt_bundle.py")]
+    cmd = [get_python_exe(), str(Path(default_crt_dir) / "gen_crt_bundle.py")]
 
     crt_args = ["--input"]
     if sdk_config.get("MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL", False):
-        crt_args.append(os.path.join(default_crt_dir, "cacrt_all.pem"))
-        crt_args.append(os.path.join(default_crt_dir, "cacrt_local.pem"))
+        crt_args.append(str(Path(default_crt_dir) / "cacrt_all.pem"))
+        crt_args.append(str(Path(default_crt_dir) / "cacrt_local.pem"))
     elif sdk_config.get("MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN", False):
-        crt_args.append(os.path.join(default_crt_dir, "cacrt_all.pem"))
-        crt_args.append(os.path.join(default_crt_dir, "cacrt_local.pem"))
+        crt_args.append(str(Path(default_crt_dir) / "cacrt_all.pem"))
+        crt_args.append(str(Path(default_crt_dir) / "cacrt_local.pem"))
         cmd.extend(
-            ["--filter", os.path.join(default_crt_dir, "cmn_crt_authorities.csv")]
+            ["--filter", str(Path(default_crt_dir) / "cmn_crt_authorities.csv")]
         )
 
     if sdk_config.get("MBEDTLS_CUSTOM_CERTIFICATE_BUNDLE", False):
@@ -1467,27 +1414,17 @@ def generate_mbedtls_bundle(sdk_config):
 
     # Use exec_command to change working directory
     exec_command(cmd + crt_args, cwd=BUILD_DIR)
-    bundle_path = os.path.join("$BUILD_DIR", "x509_crt_bundle")
+    bundle_path = str(Path("$BUILD_DIR") / "x509_crt_bundle")
     env.Execute(
         env.VerboseAction(
             " ".join(
                 [
-                    os.path.join(
-                        env.PioPlatform().get_package_dir("tool-cmake"),
-                        "bin",
-                        "cmake",
-                    ),
+                    str(Path(env.PioPlatform().get_package_dir("tool-cmake")) / "bin" / "cmake"),
                     "-DDATA_FILE=" + bundle_path,
                     "-DSOURCE_FILE=%s.S" % bundle_path,
                     "-DFILE_TYPE=BINARY",
                     "-P",
-                    os.path.join(
-                        FRAMEWORK_DIR,
-                        "tools",
-                        "cmake",
-                        "scripts",
-                        "data_file_embed_asm.cmake",
-                    ),
+                    str(Path(FRAMEWORK_DIR) / "tools" / "cmake" / "scripts" / "data_file_embed_asm.cmake"),
                 ]
             ),
             "Generating assembly for certificate bundle...",
@@ -1496,7 +1433,7 @@ def generate_mbedtls_bundle(sdk_config):
 
 
 def _get_uv_exe():
-    return get_executable_path(os.path.join(PLATFORMIO_DIR, "penv"), "uv")
+    return get_executable_path(str(Path(PLATFORMIO_DIR) / "penv"), "uv")
 
 
 def install_python_deps():
@@ -1518,7 +1455,7 @@ def install_python_deps():
 
         return result
 
-    skip_python_packages = os.path.join(FRAMEWORK_DIR, ".pio_skip_pypackages")
+    skip_python_packages = str(Path(FRAMEWORK_DIR) / ".pio_skip_pypackages")
     if os.path.isfile(skip_python_packages):
         return
 
@@ -1573,7 +1510,7 @@ def get_idf_venv_dir():
     # as an IDF component requires a different version of the IDF package and
     # hence a different set of Python deps or their versions
     idf_version = get_framework_version()
-    return os.path.join(PLATFORMIO_DIR, "penv", f".espidf-{idf_version}")
+    return str(Path(PLATFORMIO_DIR) / "penv" / f".espidf-{idf_version}")
 
 
 def ensure_python_venv_available():
@@ -1644,7 +1581,7 @@ def ensure_python_venv_available():
         ), "Error: Failed to create a proper virtual environment. Missing the Python executable!"
 
     venv_dir = get_idf_venv_dir()
-    venv_data_file = os.path.join(venv_dir, "pio-idf-venv.json")
+    venv_data_file = str(Path(venv_dir) / "pio-idf-venv.json")
     if not os.path.isfile(venv_data_file) or _is_venv_outdated(venv_data_file):
         _create_venv(venv_dir)
         install_python_deps()
@@ -1657,11 +1594,7 @@ def ensure_python_venv_available():
 
 
 def get_python_exe():
-    python_exe_path = os.path.join(
-        get_idf_venv_dir(),
-        "Scripts" if IS_WINDOWS else "bin",
-        "python" + (".exe" if IS_WINDOWS else ""),
-    )
+    python_exe_path = str(Path(get_idf_venv_dir()) / ("Scripts" if IS_WINDOWS else "bin") / ("python" + (".exe" if IS_WINDOWS else "")))
 
     assert os.path.isfile(python_exe_path), (
         "Error: Missing Python executable file `%s`" % python_exe_path
@@ -1692,34 +1625,21 @@ generate_default_component()
 #
 
 if not board.get("build.ldscript", ""):
-    initial_ld_script = board.get("build.esp-idf.ldscript", os.path.join(
-        FRAMEWORK_DIR,
-        "components",
-        "esp_system",
-        "ld",
-        idf_variant,
-        "memory.ld.in",
-    ))
+    initial_ld_script = board.get("build.esp-idf.ldscript", str(Path(FRAMEWORK_DIR) / "components" / "esp_system" / "ld" / idf_variant / "memory.ld.in"))
 
     framework_version = [int(v) for v in get_framework_version().split(".")]
     if framework_version[:2] > [5, 2]:
         initial_ld_script = preprocess_linker_file(
             initial_ld_script,
-            os.path.join(
-                BUILD_DIR,
-                "esp-idf",
-                "esp_system",
-                "ld",
-                "memory.ld.in",
-            )
+            str(Path(BUILD_DIR) / "esp-idf" / "esp_system" / "ld" / "memory.ld.in")
         )
 
     linker_script = env.Command(
-        os.path.join("$BUILD_DIR", "memory.ld"),
+        str(Path("$BUILD_DIR") / "memory.ld"),
         initial_ld_script,
         env.VerboseAction(
             '$CC -I"$BUILD_DIR/config" -I"%s" -C -P -x c -E $SOURCE -o $TARGET'
-            % os.path.join(FRAMEWORK_DIR, "components", "esp_system", "ld"),
+            % str(Path(FRAMEWORK_DIR) / "components" / "esp_system" / "ld"),
             "Generating LD script $TARGET",
         ),
     )
@@ -1751,7 +1671,7 @@ if env.subst("$SRC_FILTER"):
         )
     )
 
-if os.path.isfile(os.path.join(PROJECT_SRC_DIR, "sdkconfig.h")):
+if os.path.isfile(str(Path(PROJECT_SRC_DIR) / "sdkconfig.h")):
     print(
         "Warning! Starting with ESP-IDF v4.0, new project structure is required: \n"
         "https://docs.platformio.org/en/latest/frameworks/espidf.html#project-structure"
@@ -1765,7 +1685,7 @@ if os.path.isfile(os.path.join(PROJECT_SRC_DIR, "sdkconfig.h")):
 # default 'src' folder we need to add this as an extra component. If there is no 'main'
 # folder CMake won't generate dependencies properly
 extra_components = []
-if PROJECT_SRC_DIR != os.path.join(PROJECT_DIR, "main"):
+if PROJECT_SRC_DIR != str(Path(PROJECT_DIR) / "main"):
     extra_components.append(PROJECT_SRC_DIR)
 if "arduino" in env.subst("$PIOFRAMEWORK"):
     print(
@@ -1775,7 +1695,7 @@ if "arduino" in env.subst("$PIOFRAMEWORK"):
     extra_components.append(ARDUINO_FRAMEWORK_DIR)
     # Add path to internal Arduino libraries so that the LDF will be able to find them
     env.Append(
-        LIBSOURCE_DIRS=[os.path.join(ARDUINO_FRAMEWORK_DIR, "libraries")]
+        LIBSOURCE_DIRS=[str(Path(ARDUINO_FRAMEWORK_DIR) / "libraries")]
     )
 
 # Set ESP-IDF version environment variables (needed for proper Kconfig processing)
@@ -1797,7 +1717,7 @@ extra_cmake_args = [
 
 # This will add the linker flag for the map file
 extra_cmake_args.append(
-    f'-DCMAKE_EXE_LINKER_FLAGS=-Wl,-Map={fs.to_unix_path(os.path.join(BUILD_DIR, env.subst("$PROGNAME") + ".map"))}'
+    f'-DCMAKE_EXE_LINKER_FLAGS=-Wl,-Map={fs.to_unix_path(str(Path(BUILD_DIR) / (env.subst("$PROGNAME") + ".map")))}'
 )
 
 # Add any extra args from board config
@@ -1820,7 +1740,7 @@ if not project_codemodel:
     env.Exit(1)
 
 target_configs = load_target_configurations(
-    project_codemodel, os.path.join(BUILD_DIR, CMAKE_API_REPLY_PATH)
+    project_codemodel, str(Path(BUILD_DIR) / CMAKE_API_REPLY_PATH)
 )
 
 sdk_config = get_sdk_configuration()
@@ -1939,27 +1859,25 @@ env.AddBuildMiddleware(_skip_prj_source_files)
 # Generate partition table
 #
 
-fwpartitions_dir = os.path.join(FRAMEWORK_DIR, "components", "partition_table")
+fwpartitions_dir = str(Path(FRAMEWORK_DIR) / "components" / "partition_table")
 partitions_csv = board.get("build.partitions", "partitions_singleapp.csv")
 partition_table_offset = sdk_config.get("PARTITION_TABLE_OFFSET", 0x8000)
 
 env.Replace(
     PARTITIONS_TABLE_CSV=os.path.abspath(
-        os.path.join(fwpartitions_dir, partitions_csv)
-        if os.path.isfile(os.path.join(fwpartitions_dir, partitions_csv))
+        str(Path(fwpartitions_dir) / partitions_csv)
+        if os.path.isfile(str(Path(fwpartitions_dir) / partitions_csv))
         else partitions_csv
     )
 )
 
 partition_table = env.Command(
-    os.path.join("$BUILD_DIR", "partitions.bin"),
+    str(Path("$BUILD_DIR") / "partitions.bin"),
     "$PARTITIONS_TABLE_CSV",
     env.VerboseAction(
         '"$ESPIDF_PYTHONEXE" "%s" -q --offset "%s" --flash-size "%s" $SOURCE $TARGET'
         % (
-            os.path.join(
-                FRAMEWORK_DIR, "components", "partition_table", "gen_esp32part.py"
-            ),
+            str(Path(FRAMEWORK_DIR) / "components" / "partition_table" / "gen_esp32part.py"),
             partition_table_offset,
             board.get("upload.flash_size", "4MB"),
         ),
@@ -1987,11 +1905,11 @@ env.Prepend(
                 "upload.bootloader_offset",
                 "0x1000" if mcu in ["esp32", "esp32s2"] else ("0x2000" if mcu in ["esp32c5", "esp32p4"] else "0x0"),
             ),
-            os.path.join("$BUILD_DIR", "bootloader.bin"),
+            str(Path("$BUILD_DIR") / "bootloader.bin"),
         ),
         (
             board.get("upload.partition_table_offset", hex(partition_table_offset)),
-            os.path.join("$BUILD_DIR", "partitions.bin"),
+            str(Path("$BUILD_DIR") / "partitions.bin"),
         ),
     ],
 )
@@ -2104,7 +2022,7 @@ env["BUILDERS"]["ElfToBin"].action = action
 # Compile ULP sources in 'ulp' folder
 #
 
-ulp_dir = os.path.join(PROJECT_DIR, "ulp")
+ulp_dir = str(Path(PROJECT_DIR) / "ulp")
 if os.path.isdir(ulp_dir) and os.listdir(ulp_dir) and mcu not in ("esp32c2", "esp32c3", "esp32h2"):
     env.SConscript("ulp.py", exports="env sdk_config project_config app_includes idf_variant")
 
@@ -2114,45 +2032,45 @@ if os.path.isdir(ulp_dir) and os.listdir(ulp_dir) and mcu not in ("esp32c2", "es
 
 if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PIOFRAMEWORK")):
     def idf_lib_copy(source, target, env):
-        env_build = join(env["PROJECT_BUILD_DIR"],env["PIOENV"])
-        sdkconfig_h_path = join(env_build,"config","sdkconfig.h")
-        arduino_libs = join(ARDUINO_FRAMEWORK_DIR,"tools","esp32-arduino-libs")
-        lib_src = join(env_build,"esp-idf")
-        lib_dst = join(arduino_libs,mcu,"lib")
-        ld_dst = join(arduino_libs,mcu,"ld")
-        mem_var = join(arduino_libs,mcu,board.get("build.arduino.memory_type", (board.get("build.flash_mode", "dio") + "_qspi")))
-        src = [join(lib_src,x) for x in os.listdir(lib_src)]
+        env_build = str(Path(env["PROJECT_BUILD_DIR"]) / env["PIOENV"])
+        sdkconfig_h_path = str(Path(env_build) / "config" / "sdkconfig.h")
+        arduino_libs = str(Path(ARDUINO_FRAMEWORK_DIR) / "tools" / "esp32-arduino-libs")
+        lib_src = str(Path(env_build) / "esp-idf")
+        lib_dst = str(Path(arduino_libs) / mcu / "lib")
+        ld_dst = str(Path(arduino_libs) / mcu / "ld")
+        mem_var = str(Path(arduino_libs) / mcu / board.get("build.arduino.memory_type", (board.get("build.flash_mode", "dio") + "_qspi")))
+        src = [str(Path(lib_src) / x) for x in os.listdir(lib_src)]
         src = [folder for folder in src if not os.path.isfile(folder)] # folders only
         for folder in src:
-            files = [join(folder,x) for x in os.listdir(folder)]
+            files = [str(Path(folder) / x) for x in os.listdir(folder)]
             for file in files:
                 if file.strip().endswith(".a"):
-                    shutil.copyfile(file,join(lib_dst,file.split(os.path.sep)[-1]))
+                    shutil.copyfile(file, str(Path(lib_dst) / file.split(os.path.sep)[-1]))
 
-        shutil.move(join(lib_dst,"libspi_flash.a"),join(mem_var,"libspi_flash.a"))
-        shutil.move(join(env_build,"memory.ld"),join(ld_dst,"memory.ld"))
+        shutil.move(str(Path(lib_dst) / "libspi_flash.a"), str(Path(mem_var) / "libspi_flash.a"))
+        shutil.move(str(Path(env_build) / "memory.ld"), str(Path(ld_dst) / "memory.ld"))
         if mcu == "esp32s3":
-            shutil.move(join(lib_dst,"libesp_psram.a"),join(mem_var,"libesp_psram.a"))
-            shutil.move(join(lib_dst,"libesp_system.a"),join(mem_var,"libesp_system.a"))
-            shutil.move(join(lib_dst,"libfreertos.a"),join(mem_var,"libfreertos.a"))
-            shutil.move(join(lib_dst,"libbootloader_support.a"),join(mem_var,"libbootloader_support.a"))
-            shutil.move(join(lib_dst,"libesp_hw_support.a"),join(mem_var,"libesp_hw_support.a"))
-            shutil.move(join(lib_dst,"libesp_lcd.a"),join(mem_var,"libesp_lcd.a"))
+            shutil.move(str(Path(lib_dst) / "libesp_psram.a"), str(Path(mem_var) / "libesp_psram.a"))
+            shutil.move(str(Path(lib_dst) / "libesp_system.a"), str(Path(mem_var) / "libesp_system.a"))
+            shutil.move(str(Path(lib_dst) / "libfreertos.a"), str(Path(mem_var) / "libfreertos.a"))
+            shutil.move(str(Path(lib_dst) / "libbootloader_support.a"), str(Path(mem_var) / "libbootloader_support.a"))
+            shutil.move(str(Path(lib_dst) / "libesp_hw_support.a"), str(Path(mem_var) / "libesp_hw_support.a"))
+            shutil.move(str(Path(lib_dst) / "libesp_lcd.a"), str(Path(mem_var) / "libesp_lcd.a"))
 
-        shutil.copyfile(sdkconfig_h_path,join(mem_var,"include","sdkconfig.h"))
-        if not bool(os.path.isfile(join(arduino_libs,mcu,"sdkconfig.orig"))):
-            shutil.move(join(arduino_libs,mcu,"sdkconfig"),join(arduino_libs,mcu,"sdkconfig.orig"))
-        shutil.copyfile(join(env.subst("$PROJECT_DIR"),"sdkconfig."+env["PIOENV"]),join(arduino_libs,mcu,"sdkconfig"))
-        shutil.copyfile(join(env.subst("$PROJECT_DIR"),"sdkconfig."+env["PIOENV"]),join(arduino_libs,"sdkconfig"))
+        shutil.copyfile(sdkconfig_h_path, str(Path(mem_var) / "include" / "sdkconfig.h"))
+        if not bool(os.path.isfile(str(Path(arduino_libs) / mcu / "sdkconfig.orig"))):
+            shutil.move(str(Path(arduino_libs) / mcu / "sdkconfig"), str(Path(arduino_libs) / mcu / "sdkconfig.orig"))
+        shutil.copyfile(str(Path(env.subst("$PROJECT_DIR")) / ("sdkconfig." + env["PIOENV"])), str(Path(arduino_libs) / mcu / "sdkconfig"))
+        shutil.copyfile(str(Path(env.subst("$PROJECT_DIR")) / ("sdkconfig." + env["PIOENV"])), str(Path(arduino_libs) / "sdkconfig"))
         try:
-            os.remove(join(env.subst("$PROJECT_DIR"),"dependencies.lock"))
-            os.remove(join(env.subst("$PROJECT_DIR"),"CMakeLists.txt"))
+            os.remove(str(Path(env.subst("$PROJECT_DIR")) / "dependencies.lock"))
+            os.remove(str(Path(env.subst("$PROJECT_DIR")) / "CMakeLists.txt"))
         except:
             pass
         print("*** Copied compiled %s IDF libraries to Arduino framework ***" % idf_variant)
 
         PYTHON_EXE = env.subst("$PYTHONEXE")
-        pio_exe_path = os.path.join(os.path.dirname(PYTHON_EXE), "pio" + (".exe" if IS_WINDOWS else ""))
+        pio_exe_path = str(Path(os.path.dirname(PYTHON_EXE)) / ("pio" + (".exe" if IS_WINDOWS else "")))
         pio_cmd = env["PIOENV"]
         env.Execute(
             env.VerboseAction(
@@ -2165,7 +2083,7 @@ if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PI
         )
         if flag_custom_component_add == True or flag_custom_component_remove == True:
             try:
-                shutil.copy(join(ARDUINO_FRAMEWORK_DIR,"idf_component.yml.orig"),join(ARDUINO_FRAMEWORK_DIR,"idf_component.yml"))
+                shutil.copy(str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml.orig"), str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml"))
                 print("*** Original Arduino \"idf_component.yml\" restored ***")
             except:
                 print("*** Original Arduino \"idf_component.yml\" couldnt be restored ***")
@@ -2179,15 +2097,15 @@ if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PI
 if "espidf" in env.subst("$PIOFRAMEWORK") and (flag_custom_component_add == True or flag_custom_component_remove == True):
     def idf_custom_component(source, target, env):
         try:
-            shutil.copy(join(ARDUINO_FRAMEWORK_DIR,"idf_component.yml.orig"),join(ARDUINO_FRAMEWORK_DIR,"idf_component.yml"))
+            shutil.copy(str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml.orig"), str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml"))
             print("*** Original Arduino \"idf_component.yml\" restored ***")
         except:
             try:
-                shutil.copy(join(PROJECT_SRC_DIR,"idf_component.yml.orig"),join(PROJECT_SRC_DIR,"idf_component.yml"))
+                shutil.copy(str(Path(PROJECT_SRC_DIR) / "idf_component.yml.orig"), str(Path(PROJECT_SRC_DIR) / "idf_component.yml"))
                 print("*** Original \"idf_component.yml\" restored ***")
             except: # no "idf_component.yml" in source folder
                 try:
-                    os.remove(join(PROJECT_SRC_DIR,"idf_component.yml"))
+                    os.remove(str(Path(PROJECT_SRC_DIR) / "idf_component.yml"))
                     print("*** pioarduino generated \"idf_component.yml\" removed ***")
                 except:
                     print("*** no custom \"idf_component.yml\" found for removing ***")
@@ -2198,6 +2116,7 @@ if "espidf" in env.subst("$PIOFRAMEWORK") and (flag_custom_component_add == True
             component_manager.restore_pioarduino_build_py()
     silent_action = create_silent_action(idf_custom_component)
     env.AddPostAction("checkprogsize", silent_action)
+
 #
 # Process OTA partition and image
 #
@@ -2210,9 +2129,9 @@ ota_partition_params = get_partition_info(
 
 if ota_partition_params["size"] and ota_partition_params["offset"]:
     # Generate an empty image if OTA is enabled in partition table
-    ota_partition_image = os.path.join("$BUILD_DIR", "ota_data_initial.bin")
+    ota_partition_image = str(Path("$BUILD_DIR") / "ota_data_initial.bin")
     if "arduino" in env.subst("$PIOFRAMEWORK"):
-        ota_partition_image = os.path.join(ARDUINO_FRAMEWORK_DIR, "tools", "partitions", "boot_app0.bin")
+        ota_partition_image = str(Path(ARDUINO_FRAMEWORK_DIR) / "tools" / "partitions" / "boot_app0.bin")
     else:
         generate_empty_partition_image(ota_partition_image, ota_partition_params["size"])
 
@@ -2226,10 +2145,10 @@ if ota_partition_params["size"] and ota_partition_params["offset"]:
             )
         ]
     )
-    EXTRA_IMG_DIR = join(env.subst("$PROJECT_DIR"), "variants", "tasmota")
+    EXTRA_IMG_DIR = str(Path(env.subst("$PROJECT_DIR")) / "variants" / "tasmota")
     env.Append(
         FLASH_EXTRA_IMAGES=[
-            (offset, join(EXTRA_IMG_DIR, img)) for offset, img in board.get("upload.arduino.flash_extra_images", [])
+            (offset, str(Path(EXTRA_IMG_DIR) / img)) for offset, img in board.get("upload.arduino.flash_extra_images", [])
         ]
     )
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -80,7 +80,11 @@ flag_custom_component_add = False
 flag_custom_component_remove = False
 
 IDF_ENV_VERSION = "1.0.0"
-FRAMEWORK_DIR_PATH = Path(platform.get_package_dir("framework-espidf")).resolve()
+_framework_pkg_dir = platform.get_package_dir("framework-espidf")
+if not _framework_pkg_dir or not os.path.isdir(_framework_pkg_dir):
+    sys.stderr.write(f"Error: Missing framework directory '{_framework_pkg_dir}'\n")
+    env.Exit(1)
+FRAMEWORK_DIR_PATH = Path(_framework_pkg_dir).resolve()
 FRAMEWORK_DIR = str(FRAMEWORK_DIR_PATH)
 TOOLCHAIN_DIR = platform.get_package_dir(
     "toolchain-xtensa-esp-elf"

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -446,6 +446,13 @@ def normalize_path(path):
     return fs.to_unix_path(path)
 
 
+CMK_DIR = platform.get_package_dir("tool-cmake")
+if not CMK_DIR or not os.path.isdir(CMK_DIR):
+    sys.stderr.write(f"Error: Missing CMake package directory '{CMK_DIR}'\n")
+    env.Exit(1)
+CMAKE_EXE = str(Path(CMK_DIR) / "bin" / "cmake")
+
+
 def create_default_project_files():
     root_cmake_tpl = """cmake_minimum_required(VERSION 3.16.0)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
@@ -511,7 +518,7 @@ def populate_idf_env_vars(idf_env):
     additional_packages = [
         str(Path(TOOLCHAIN_DIR) / "bin"),
         platform.get_package_dir("tool-ninja"),
-        str(Path(platform.get_package_dir("tool-cmake")) / "bin"),
+        CMAKE_EXE
         os.path.dirname(get_python_exe()),
     ]
 
@@ -1031,13 +1038,6 @@ def run_tool(cmd):
     if int(ARGUMENTS.get("PIOVERBOSE", 0)):
         print(result["out"])
         print(result["err"])
-
-
-CMK_DIR = platform.get_package_dir("tool-cmake")
-if not CMK_DIR or not os.path.isdir(CMK_DIR):
-    sys.stderr.write(f"Error: Missing CMake package directory '{CMK_DIR}'\n")
-    env.Exit(1)
-CMAKE_EXE = str(Path(CMK_DIR) / "bin" / "cmake")
 
 
 def RunMenuconfig(target, source, env):

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -96,7 +96,7 @@ PLATFORMIO_DIR = env.subst("$PROJECT_CORE_DIR")
 if not os.path.isdir(FRAMEWORK_DIR):
     sys.stderr.write(f"Error: Missing framework directory '{FRAMEWORK_DIR}'\n")
     env.Exit(1)
-if not os.path.isdir(TOOLCHAIN_DIR):
+if not TOOLCHAIN_DIR or not os.path.isdir(TOOLCHAIN_DIR):
     sys.stderr.write(f"Error: Missing toolchain directory '{TOOLCHAIN_DIR}'\n")
     env.Exit(1)
 
@@ -108,8 +108,11 @@ def create_silent_action(action_func):
     return silent_action
 
 if "arduino" in env.subst("$PIOFRAMEWORK"):
-    arduino_pkg_dir = Path(platform.get_package_dir("framework-arduinoespressif32"))
-    # Rename using the symlink path (do not resolve before rename)
+    _arduino_pkg_dir = platform.get_package_dir("framework-arduinoespressif32")
+    if not _arduino_pkg_dir or not os.path.isdir(_arduino_pkg_dir):
+        sys.stderr.write(f"Error: Missing Arduino framework directory '{_arduino_pkg_dir}'\n")
+        env.Exit(1)
+    arduino_pkg_dir = Path(_arduino_pkg_dir)
     if "@" in arduino_pkg_dir.name:
         new_dir = arduino_pkg_dir.with_name(arduino_pkg_dir.name.replace("@", "-"))
         os.rename(str(arduino_pkg_dir), str(new_dir))
@@ -2104,7 +2107,6 @@ if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PI
 if "espidf" in env.subst("$PIOFRAMEWORK") and (flag_custom_component_add == True or flag_custom_component_remove == True):
     def idf_custom_component(source, target, env):
         try:
-            # Add this check before using ARDUINO_FRAMEWORK_DIR
             if "arduino" in env.subst("$PIOFRAMEWORK"):
                 shutil.copy(str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml.orig"),
                             str(Path(ARDUINO_FRAMEWORK_DIR) / "idf_component.yml"))

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -450,8 +450,7 @@ CMK_DIR = platform.get_package_dir("tool-cmake")
 if not CMK_DIR or not os.path.isdir(CMK_DIR):
     sys.stderr.write(f"Error: Missing CMake package directory '{CMK_DIR}'\n")
     env.Exit(1)
-cmake_name = "cmake.exe" if IS_WINDOWS else "cmake"
-CMAKE_EXE = str(Path(CMK_DIR) / "bin" / _cmake_name)
+CMAKE_EXE = str(Path(CMK_DIR) / "bin" / "cmake")
 
 
 def create_default_project_files():
@@ -523,7 +522,7 @@ def populate_idf_env_vars(idf_env):
     additional_packages = [
         str(Path(TOOLCHAIN_DIR) / "bin"),
         NINJA_DIR,
-        str(Path(CMAKE_EXE).parent),
+        CMAKE_EXE,
         os.path.dirname(get_python_exe()),
     ]
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2022,6 +2022,14 @@ if os.path.isdir(ulp_dir) and os.listdir(ulp_dir) and mcu not in ("esp32c2", "es
 
 if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PIOFRAMEWORK")):
     def idf_lib_copy(source, target, env):
+        def _replace_move(src, dst):
+            dst_p = Path(dst)
+            dst_p.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                os.remove(dst)
+            except FileNotFoundError:
+                pass
+            shutil.move(src, dst)
         env_build = str(Path(env["PROJECT_BUILD_DIR"]) / env["PIOENV"])
         sdkconfig_h_path = str(Path(env_build) / "config" / "sdkconfig.h")
         arduino_libs = str(Path(ARDUINO_FRAMEWORK_DIR) / "tools" / "esp32-arduino-libs")
@@ -2029,6 +2037,9 @@ if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PI
         lib_dst = str(Path(arduino_libs) / mcu / "lib")
         ld_dst = str(Path(arduino_libs) / mcu / "ld")
         mem_var = str(Path(arduino_libs) / mcu / board.get("build.arduino.memory_type", (board.get("build.flash_mode", "dio") + "_qspi")))
+        # Ensure destinations exist
+        for d in (lib_dst, ld_dst, mem_var, str(Path(mem_var) / "include")):
+            Path(d).mkdir(parents=True, exist_ok=True)
         src = [str(Path(lib_src) / x) for x in os.listdir(lib_src)]
         src = [folder for folder in src if not os.path.isfile(folder)] # folders only
         for folder in src:
@@ -2037,15 +2048,15 @@ if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PI
                 if file.strip().endswith(".a"):
                     shutil.copyfile(file, str(Path(lib_dst) / file.split(os.path.sep)[-1]))
 
-        shutil.move(str(Path(lib_dst) / "libspi_flash.a"), str(Path(mem_var) / "libspi_flash.a"))
-        shutil.move(str(Path(env_build) / "memory.ld"), str(Path(ld_dst) / "memory.ld"))
+        _replace_move(str(Path(lib_dst) / "libspi_flash.a"), str(Path(mem_var) / "libspi_flash.a"))
+        _replace_move(str(Path(env_build) / "memory.ld"), str(Path(ld_dst) / "memory.ld"))
         if mcu == "esp32s3":
-            shutil.move(str(Path(lib_dst) / "libesp_psram.a"), str(Path(mem_var) / "libesp_psram.a"))
-            shutil.move(str(Path(lib_dst) / "libesp_system.a"), str(Path(mem_var) / "libesp_system.a"))
-            shutil.move(str(Path(lib_dst) / "libfreertos.a"), str(Path(mem_var) / "libfreertos.a"))
-            shutil.move(str(Path(lib_dst) / "libbootloader_support.a"), str(Path(mem_var) / "libbootloader_support.a"))
-            shutil.move(str(Path(lib_dst) / "libesp_hw_support.a"), str(Path(mem_var) / "libesp_hw_support.a"))
-            shutil.move(str(Path(lib_dst) / "libesp_lcd.a"), str(Path(mem_var) / "libesp_lcd.a"))
+            _replace_move(str(Path(lib_dst) / "libesp_psram.a"), str(Path(mem_var) / "libesp_psram.a"))
+            _replace_move(str(Path(lib_dst) / "libesp_system.a"), str(Path(mem_var) / "libesp_system.a"))
+            _replace_move(str(Path(lib_dst) / "libfreertos.a"), str(Path(mem_var) / "libfreertos.a"))
+            _replace_move(str(Path(lib_dst) / "libbootloader_support.a"), str(Path(mem_var) / "libbootloader_support.a"))
+            _replace_move(str(Path(lib_dst) / "libesp_hw_support.a"), str(Path(mem_var) / "libesp_hw_support.a"))
+            _replace_move(str(Path(lib_dst) / "libesp_lcd.a"), str(Path(mem_var) / "libesp_lcd.a"))
 
         shutil.copyfile(sdkconfig_h_path, str(Path(mem_var) / "include" / "sdkconfig.h"))
         if not bool(os.path.isfile(str(Path(arduino_libs) / mcu / "sdkconfig.orig"))):

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1420,7 +1420,7 @@ def generate_mbedtls_bundle(sdk_config):
         env.VerboseAction(
             " ".join(
                 [
-                    str(Path(env.PioPlatform().get_package_dir("tool-cmake")) / "bin" / "cmake"),
+                    CMAKE_EXE,
                     "-DDATA_FILE=" + bundle_path,
                     "-DSOURCE_FILE=%s.S" % bundle_path,
                     "-DFILE_TYPE=BINARY",
@@ -1671,12 +1671,6 @@ if env.subst("$SRC_FILTER"):
         )
     )
 
-if os.path.isfile(str(Path(PROJECT_SRC_DIR) / "sdkconfig.h")):
-    print(
-        "Warning! Starting with ESP-IDF v4.0, new project structure is required: \n"
-        "https://docs.platformio.org/en/latest/frameworks/espidf.html#project-structure"
-    )
-
 #
 # Initial targets loading
 #
@@ -1688,10 +1682,6 @@ extra_components = []
 if PROJECT_SRC_DIR != str(Path(PROJECT_DIR) / "main"):
     extra_components.append(str(Path(PROJECT_SRC_DIR).resolve()))
 if "arduino" in env.subst("$PIOFRAMEWORK"):
-    print(
-        "Warning! Arduino framework as an ESP-IDF component doesn't handle "
-        "the `variant` field! The default `esp32` variant will be used."
-    )
     extra_components.append(ARDUINO_FRAMEWORK_DIR)
     # Add path to internal Arduino libraries so that the LDF will be able to find them
     env.Append(

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2112,11 +2112,11 @@ if "espidf" in env.subst("$PIOFRAMEWORK") and (flag_custom_component_add == True
             try:
                 shutil.copy(str(Path(PROJECT_SRC_DIR) / "idf_component.yml.orig"), str(Path(PROJECT_SRC_DIR) / "idf_component.yml"))
                 print("*** Original \"idf_component.yml\" restored ***")
-            except: # no "idf_component.yml" in source folder
+            except (FileNotFoundError, PermissionError, OSError): # no "idf_component.yml" in source folder
                 try:
                     os.remove(str(Path(PROJECT_SRC_DIR) / "idf_component.yml"))
                     print("*** pioarduino generated \"idf_component.yml\" removed ***")
-                except:
+                except (FileNotFoundError, PermissionError, OSError):
                     print("*** no custom \"idf_component.yml\" found for removing ***")
         if "arduino" in env.subst("$PIOFRAMEWORK"):
             # Restore original pioarduino-build.py, only used with Arduino

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1373,7 +1373,7 @@ def preprocess_linker_file(src_ld_script, target_ld_script):
         env.VerboseAction(
             " ".join(
                 [
-                    CMAKE_EXE,
+                    CMAKE_DIR,
                     "-DCC=%s" % str(Path(TOOLCHAIN_DIR) / "bin" / "$CC"),
                     "-DSOURCE=$SOURCE",
                     "-DTARGET=$TARGET",

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -31,6 +31,7 @@ from os.path import join
 import re
 import requests
 import platform as sys_platform
+from pathlib import Path
 
 import click
 import semantic_version
@@ -998,7 +999,10 @@ def compile_source_files(
 ):
     build_envs = prepare_build_envs(config, default_env, debug_allowed)
     objects = []
-    components_dir = fs.to_unix_path(os.path.join(FRAMEWORK_DIR, "components"))
+    # The source "path" will have had any symlinks resolved, so resolve any
+    components_dir = str(
+        Path(fs.to_unix_path(os.path.join(FRAMEWORK_DIR, "components"))).resolve()
+    )
     for source in config.get("sources", []):
         if source["path"].endswith(".rule"):
             continue
@@ -1013,7 +1017,7 @@ def compile_source_files(
                 src_path = os.path.join(project_src_dir, src_path)
 
             obj_path = os.path.join("$BUILD_DIR", prepend_dir or "")
-            if src_path.lower().startswith(components_dir.lower()):
+            if str(Path(src_path).resolve()).lower().startswith(components_dir.lower()):
                 obj_path = os.path.join(
                     obj_path, os.path.relpath(src_path, components_dir)
                 )

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -982,7 +982,6 @@ def compile_source_files(
     objects = []
     # Canonical, symlink-resolved absolute path of the components directory
     components_dir_path = (Path(FRAMEWORK_DIR) / "components").resolve()
-    components_dir = str(components_dir_path)
     for source in config.get("sources", []):
         if source["path"].endswith(".rule"):
             continue
@@ -1692,7 +1691,7 @@ if os.path.isfile(str(Path(PROJECT_SRC_DIR) / "sdkconfig.h")):
 # folder CMake won't generate dependencies properly
 extra_components = []
 if PROJECT_SRC_DIR != str(Path(PROJECT_DIR) / "main"):
-    extra_components.append(PROJECT_SRC_DIR)
+    extra_components.append(str(Path(PROJECT_SRC_DIR).resolve()))
 if "arduino" in env.subst("$PIOFRAMEWORK"):
     print(
         "Warning! Arduino framework as an ESP-IDF component doesn't handle "
@@ -1713,7 +1712,7 @@ os.environ["ESP_IDF_VERSION"] = major_version
 extra_cmake_args = [
     "-DIDF_TARGET=" + idf_variant,
     "-DPYTHON_DEPS_CHECKED=1",
-    "-DEXTRA_COMPONENT_DIRS:PATH=" + ";".join(extra_components),
+    "-DEXTRA_COMPONENT_DIRS:PATH=" + ";".join(str(Path(p).resolve()) for p in extra_components),
     "-DPYTHON=" + get_python_exe(),
     "-DSDKCONFIG=" + SDKCONFIG_PATH,
     f"-DESP_IDF_VERSION={major_version}",
@@ -1852,11 +1851,13 @@ except:
 # Remove project source files from following build stages as they're
 # built as part of the framework
 def _skip_prj_source_files(node):
-    resolved_project_src = str(Path(PROJECT_SRC_DIR).resolve())
-    resolved_node_path = str(Path(node.srcnode().get_path()).resolve())
-    if resolved_node_path.lower().startswith(resolved_project_src.lower()):
+    project_src_resolved = Path(PROJECT_SRC_DIR).resolve()
+    node_path_resolved = Path(node.srcnode().get_path()).resolve()
+    try:
+        node_path_resolved.relative_to(project_src_resolved)
         return None
-    return node
+    except ValueError:
+        return node
 
 
 env.AddBuildMiddleware(_skip_prj_source_files)
@@ -2071,8 +2072,10 @@ if ("arduino" in env.subst("$PIOFRAMEWORK")) and ("espidf" not in env.subst("$PI
         try:
             os.remove(str(Path(env.subst("$PROJECT_DIR")) / "dependencies.lock"))
             os.remove(str(Path(env.subst("$PROJECT_DIR")) / "CMakeLists.txt"))
-        except:
+        except FileNotFoundError:
             pass
+        except OSError as e:
+            print(f"Warning: cleanup failed: {e}")
         print("*** Copied compiled %s IDF libraries to Arduino framework ***" % idf_variant)
 
         PYTHON_EXE = env.subst("$PYTHONEXE")

--- a/builder/main.py
+++ b/builder/main.py
@@ -560,11 +560,11 @@ def firmware_metrics(target, source, env):
         return
 
     map_file = str(Path(env.subst("$BUILD_DIR")) / (env.subst("$PROGNAME") + ".map"))
-    if not isfile(map_file):
+    if not Path(map_file).is_file():
         # map file can be in project dir
         map_file = str(Path(get_project_dir()) / (env.subst("$PROGNAME") + ".map"))
 
-    if not isfile(map_file):
+    if not Path(map_file).is_file():
         print(f"Error: Map file not found: {map_file}")
         print("Make sure the project is built first with 'pio run'")
         return
@@ -692,7 +692,7 @@ if upload_protocol == "espota":
             "espressif32.html#over-the-air-ota-update\n"
         )
     env.Replace(
-        UPLOADER=str(Path(FRAMEWORK_DIR) / "tools" / "espota.py"),
+        UPLOADER=str(Path(FRAMEWORK_DIR).resolve() / "tools" / "espota.py"),
         UPLOADERFLAGS=["--debug", "--progress", "-i", "$UPLOAD_PORT"],
         UPLOADCMD=f'"{PYTHON_EXE}" "$UPLOADER" $UPLOADERFLAGS -f $SOURCE',
     )

--- a/builder/main.py
+++ b/builder/main.py
@@ -19,6 +19,7 @@ import shlex
 import subprocess
 import sys
 from os.path import isfile, join
+from pathlib import Path
 
 from SCons.Script import (
     ARGUMENTS,
@@ -444,16 +445,9 @@ env.Replace(
     AS="%s-elf-as" % toolchain_arch,
     CC="%s-elf-gcc" % toolchain_arch,
     CXX="%s-elf-g++" % toolchain_arch,
-    GDB=join(
-        platform.get_package_dir(
-            "tool-riscv32-esp-elf-gdb"
-            if not is_xtensa
-            else "tool-xtensa-esp-elf-gdb"
-        )
-        or "",
-        "bin",
-        "%s-elf-gdb" % toolchain_arch,
-    ),
+    GDB=str(Path(platform.get_package_dir("tool-riscv32-esp-elf-gdb")
+        if not is_xtensa
+        else platform.get_package_dir("tool-xtensa-esp-elf-gdb")) or "") / "bin" / f"{toolchain_arch}-elf-gdb",
     OBJCOPY=uploader_path,
     RANLIB="%s-elf-gcc-ranlib" % toolchain_arch,
     SIZETOOL="%s-elf-size" % toolchain_arch,
@@ -558,12 +552,12 @@ def firmware_metrics(target, source, env):
         print("Firmware metrics can not be shown. Set the terminal codepage to \"utf-8\"")
         return
 
-    map_file = os.path.join(env.subst("$BUILD_DIR"), env.subst("$PROGNAME") + ".map")
-    if not os.path.isfile(map_file):
+    map_file = str(Path(env.subst("$BUILD_DIR")) / (env.subst("$PROGNAME") + ".map"))
+    if not isfile(map_file):
         # map file can be in project dir
-        map_file = os.path.join(get_project_dir(), env.subst("$PROGNAME") + ".map")
+        map_file = str(Path(get_project_dir()) / (env.subst("$PROGNAME") + ".map"))
 
-    if not os.path.isfile(map_file):
+    if not isfile(map_file):
         print(f"Error: Map file not found: {map_file}")
         print("Make sure the project is built first with 'pio run'")
         return
@@ -614,12 +608,12 @@ def firmware_metrics(target, source, env):
 
 target_elf = None
 if "nobuild" in COMMAND_LINE_TARGETS:
-    target_elf = join("$BUILD_DIR", "${PROGNAME}.elf")
+    target_elf = str(Path("$BUILD_DIR") / "${PROGNAME}.elf")
     if set(["uploadfs", "uploadfsota"]) & set(COMMAND_LINE_TARGETS):
         fetch_fs_size(env)
-        target_firm = join("$BUILD_DIR", "${ESP32_FS_IMAGE_NAME}.bin")
+        target_firm = str(Path("$BUILD_DIR") / "${ESP32_FS_IMAGE_NAME}.bin")
     else:
-        target_firm = join("$BUILD_DIR", "${PROGNAME}.bin")
+        target_firm = str(Path("$BUILD_DIR") / "${PROGNAME}.bin")
 else:
     target_elf = env.BuildProgram()
     silent_action = env.Action(firmware_metrics)
@@ -628,12 +622,12 @@ else:
     env.AddPostAction(target_elf, silent_action)
     if set(["buildfs", "uploadfs", "uploadfsota"]) & set(COMMAND_LINE_TARGETS):
         target_firm = env.DataToBin(
-            join("$BUILD_DIR", "${ESP32_FS_IMAGE_NAME}"), "$PROJECT_DATA_DIR"
+            str(Path("$BUILD_DIR") / "${ESP32_FS_IMAGE_NAME}"), "$PROJECT_DATA_DIR"
         )
         env.NoCache(target_firm)
         AlwaysBuild(target_firm)
     else:
-        target_firm = env.ElfToBin(join("$BUILD_DIR", "${PROGNAME}"), target_elf)
+        target_firm = env.ElfToBin(str(Path("$BUILD_DIR") / "${PROGNAME}"), target_elf)
         env.Depends(target_firm, "checkprogsize")
 
 # Configure platform targets
@@ -691,7 +685,7 @@ if upload_protocol == "espota":
             "espressif32.html#over-the-air-ota-update\n"
         )
     env.Replace(
-        UPLOADER=join(FRAMEWORK_DIR, "tools", "espota.py"),
+        UPLOADER=str(Path(FRAMEWORK_DIR) / "tools" / "espota.py"),
         UPLOADERFLAGS=["--debug", "--progress", "-i", "$UPLOAD_PORT"],
         UPLOADCMD=f'"{PYTHON_EXE}" "$UPLOADER" $UPLOADERFLAGS -f $SOURCE',
     )

--- a/builder/main.py
+++ b/builder/main.py
@@ -445,9 +445,16 @@ env.Replace(
     AS="%s-elf-as" % toolchain_arch,
     CC="%s-elf-gcc" % toolchain_arch,
     CXX="%s-elf-g++" % toolchain_arch,
-    GDB=str(Path(platform.get_package_dir("tool-riscv32-esp-elf-gdb")
-        if not is_xtensa
-        else platform.get_package_dir("tool-xtensa-esp-elf-gdb")) or "") / "bin" / f"{toolchain_arch}-elf-gdb",
+    GDB=join(
+        platform.get_package_dir(
+            "tool-riscv32-esp-elf-gdb"
+            if not is_xtensa
+            else "tool-xtensa-esp-elf-gdb"
+        )
+        or "",
+        "bin",
+        "%s-elf-gdb" % toolchain_arch,
+    ),
     OBJCOPY=uploader_path,
     RANLIB="%s-elf-gcc-ranlib" % toolchain_arch,
     SIZETOOL="%s-elf-size" % toolchain_arch,

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -20,6 +20,7 @@ import semantic_version
 import subprocess
 import sys
 import socket
+from pathlib import Path
 
 from platformio.package.version import pepver_to_semver
 from platformio.compat import IS_WINDOWS
@@ -77,7 +78,7 @@ def get_executable_path(penv_dir, executable_name):
     exe_suffix = ".exe" if IS_WINDOWS else ""
     scripts_dir = "Scripts" if IS_WINDOWS else "bin"
     
-    return os.path.join(penv_dir, scripts_dir, f"{executable_name}{exe_suffix}")
+    return str(Path(penv_dir) / scripts_dir / f"{executable_name}{exe_suffix}")
 
 
 def setup_pipenv_in_package(env, penv_dir):
@@ -97,7 +98,7 @@ def setup_pipenv_in_package(env, penv_dir):
             python_exe = env.subst("$PYTHONEXE")
             python_dir = os.path.dirname(python_exe)
             uv_exe_suffix = ".exe" if IS_WINDOWS else ""
-            uv_cmd = os.path.join(python_dir, f"uv{uv_exe_suffix}")
+            uv_cmd = str(Path(python_dir) / f"uv{uv_exe_suffix}")
             
             # Fall back to system uv if derived path doesn't exist
             if not os.path.isfile(uv_cmd):
@@ -141,8 +142,8 @@ def setup_python_paths(penv_dir):
     # Add site-packages directory
     python_ver = f"python{sys.version_info.major}.{sys.version_info.minor}"
     site_packages = (
-        os.path.join(penv_dir, "Lib", "site-packages") if IS_WINDOWS
-        else os.path.join(penv_dir, "lib", python_ver, "site-packages")
+        str(Path(penv_dir) / "Lib" / "site-packages") if IS_WINDOWS
+        else str(Path(penv_dir) / "lib" / python_ver / "site-packages")
     )
     
     if os.path.isdir(site_packages):
@@ -423,7 +424,7 @@ def setup_python_environment(env, platform, platformio_dir):
         )
         sys.exit(1)
 
-    penv_dir = os.path.join(platformio_dir, "penv")
+    penv_dir = str(Path(platformio_dir) / "penv")
     
     # Setup virtual environment if needed
     used_uv_executable = setup_pipenv_in_package(env, penv_dir)

--- a/platform.json
+++ b/platform.json
@@ -33,7 +33,7 @@
       "type": "framework",
       "optional": true,
       "owner": "tasmota",
-      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/0209-1120-5.3/framework-arduinoespressif32-release_v5.3-d3cc95fe.zip"
+      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/0309-1532-5.3/framework-arduinoespressif32-release_v5.3-d3cc95fe.zip"
     },
     "framework-espidf": {
       "type": "framework",


### PR DESCRIPTION
Refactor components directory path resolution to use pathlib for better compatibility and clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Better detection of path traversal and clearer errors for missing/invalid frameworks, Arduino SDKs, or toolchains; more resilient handling of symlinked/moved projects and file lookups.

- **Refactor**
  - Full migration to pathlib-style path handling for consistent, cross-platform path construction and canonicalization across builds and tooling.

- **Chores**
  - Updated Arduino framework package reference and modernized CMake/tool resolution for more reliable build/tool invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->