### PR TITLE
fix Arduino as an component of IDF compile

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1006,9 +1006,12 @@ def compile_source_files(
     for source in config.get("sources", []):
         if source["path"].endswith(".rule"):
             continue
+        src_path = source.get("path")
+        # Always skip dummy_src.c to avoid duplicate build actions
+        if os.path.basename(src_path) == "dummy_src.c":
+            continue
         compile_group_idx = source.get("compileGroupIndex")
         if compile_group_idx is not None:
-            src_path = source.get("path")
             if not os.path.isabs(src_path):
                 # For cases when sources are located near CMakeLists.txt
                 src_path = str(Path(project_src_dir) / src_path)
@@ -1033,16 +1036,23 @@ def compile_source_files(
                 "build.esp-idf.preserve_source_file_extension", "yes"
             ) == "yes"
 
-            objects.append(
-                build_envs[compile_group_idx].StaticObject(
-                    target=(
-                        obj_path
-                        if preserve_source_file_extension
-                        else os.path.splitext(obj_path)[0]
-                    ) + ".o",
-                    source=str(src_path_obj),
+            obj_target = (
+                obj_path
+                if preserve_source_file_extension
+                else os.path.splitext(obj_path)[0]
+            ) + ".o"
+            # Only add if this object file is not already in the list
+            # If it's a dummy_src.c.o duplicate, skip it to avoid build conflicts
+            if any(getattr(obj, 'target', None) == obj_target for obj in objects):
+                if os.path.basename(obj_target) == "dummy_src.c.o":
+                    continue
+            else:
+                objects.append(
+                    build_envs[compile_group_idx].StaticObject(
+                        target=obj_target,
+                        source=str(src_path_obj),
+                    )
                 )
-            )
 
     return objects
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1036,23 +1036,16 @@ def compile_source_files(
                 "build.esp-idf.preserve_source_file_extension", "yes"
             ) == "yes"
 
-            obj_target = (
-                obj_path
-                if preserve_source_file_extension
-                else os.path.splitext(obj_path)[0]
-            ) + ".o"
-            # Only add if this object file is not already in the list
-            # If it's a dummy_src.c.o duplicate, skip it to avoid build conflicts
-            if any(getattr(obj, 'target', None) == obj_target for obj in objects):
-                if os.path.basename(obj_target) == "dummy_src.c.o":
-                    continue
-            else:
-                objects.append(
-                    build_envs[compile_group_idx].StaticObject(
-                        target=obj_target,
-                        source=str(src_path_obj),
-                    )
+            objects.append(
+                build_envs[compile_group_idx].StaticObject(
+                    target=(
+                        obj_path
+                        if preserve_source_file_extension
+                        else os.path.splitext(obj_path)[0]
+                    ) + ".o",
+                    source=str(src_path_obj),
                 )
+            )
 
     return objects
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1004,9 +1004,9 @@ def compile_source_files(
     # Canonical, symlink-resolved absolute path of the components directory
     components_dir_path = (Path(FRAMEWORK_DIR) / "components").resolve()
     for source in config.get("sources", []):
-        if source["path"].endswith(".rule"):
+        src_path = source["path"]
+        if src_path.endswith(".rule"):
             continue
-        src_path = source.get("path")
         # Always skip dummy_src.c to avoid duplicate build actions
         if os.path.basename(src_path) == "dummy_src.c":
             continue


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Placeholder/dummy source files and build rule files are now ignored, preventing unnecessary build actions and reducing compilation noise.
* **Refactor**
  * Unified source path handling in the build flow for more consistent path resolution and fewer edge-case issues, improving build reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->