### PR TITLE
support for c61

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Espressif Systems is a privately held, fabless semiconductor company renowned fo
 1. [Install PlatformIO](http://platformio.org)
 2. Create PlatformIO project and configure a platform option in [platformio.ini](http://docs.platformio.org/page/projectconf.html) file:
 
-### Arduino 3.3.1+ and IDF 5.5.1+ (build from development sources)
-Support for the ESP32/ESP32solo1, ESP32C2, ESP32C3, ESP32C5, ESP32C6, ESP32S2, ESP32S3, ESP32-H2 and ESP32-P4
+### Arduino 3.3.4+ and IDF 5.5.1+ (build from development sources)
+Support for the ESP32/ESP32solo1, ESP32S2, ESP32S3, ESP32C2, ESP32C3, ESP32C5, ESP32C6, ESP32C61, ESP32-H2 and ESP32-P4
 
 ```                  
 [platformio]

--- a/boards/esp32-c61-devkitc1-n8r2.json
+++ b/boards/esp32-c61-devkitc1-n8r2.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "arduino": {
+        "partitions": "default_8MB.csv",
+        "memory_type": "qio_qspi"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DBOARD_HAS_PSRAM"
+    ],    
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "psram_type": "qio",
+    "mcu": "esp32c61",
+    "variant": "esp32c61"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32c61.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Espressif ESP32-C61-DevKitC-1 N8R2 (8 MB Flash Quad, 2 MB PSRAM Quad)",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32c61/esp32-c61-devkitc-1/user_guide.html",
+  "vendor": "Espressif"
+}

--- a/boards/esp32-c61-devkitc1-n8r2.json
+++ b/boards/esp32-c61-devkitc1-n8r2.json
@@ -8,7 +8,7 @@
     "extra_flags": [
       "-DBOARD_HAS_PSRAM"
     ],    
-    "f_cpu": "240000000L",
+    "f_cpu": "160000000L",
     "f_flash": "80000000L",
     "flash_mode": "qio",
     "psram_type": "qio",

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -74,7 +74,9 @@ def get_platform_default_threshold(mcu):
         "esp32s3": 32766,    # ESP32-S3
         "esp32c3": 32000,    # ESP32-C3
         "esp32c2": 31600,    # ESP32-C2
+        "esp32c5": 31600,    # ESP32-C5
         "esp32c6": 31600,    # ESP32-C6
+        "esp32c61": 31600,   # ESP32-C61
         "esp32h2": 32000,    # ESP32-H2
         "esp32p4": 32000,    # ESP32-P4
     }
@@ -105,11 +107,13 @@ def validate_threshold(threshold, mcu):
     mcu_adjustments = {
         "esp32c2": {"min": 30000, "max": 32767},
         "esp32c3": {"min": 30000, "max": 32767},
+        "esp32c5": {"min": 30000, "max": 32767},
         "esp32": {"min": 30000, "max": 32767},
         "esp32s2": {"min": 30000, "max": 32767},
         "esp32s3": {"min": 30000, "max": 32767},
         "esp32p4": {"min": 30000, "max": 32767},
         "esp32c6": {"min": 30000, "max": 32767},
+        "esp32c61": {"min": 30000, "max": 32767},
         "esp32h2": {"min": 30000, "max": 32767},
     }
 

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -79,6 +79,22 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp32-camera
                           joltwallet/littlefs
 
+[env:esp32-c61-devkitc1-n8r2]
+platform = espressif32
+framework = arduino
+build_type = debug
+board = esp32-c61-devkitc1-n8r2
+monitor_speed = 115200
+lib_ignore              = ble
+                          wifi
+custom_component_remove = espressif/esp_hosted
+                          espressif/esp_wifi_remote
+                          espressif/mdns
+                          espressif/esp-dsp
+                          espressif/esp_modem
+                          espressif/esp32-camera
+                          joltwallet/littlefs
+
 [env:esp32-h2-devkitm-1]
 platform = espressif32
 framework = arduino

--- a/platform.json
+++ b/platform.json
@@ -33,7 +33,7 @@
       "type": "framework",
       "optional": true,
       "owner": "tasmota",
-      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/1311-1259-5.5/framework-arduinoespressif32-release_v5.5-15833ebc.tar.xz"
+      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/1311-1426-5.5/framework-arduinoespressif32-release_v5.5-15833ebc.tar.xz"
     },
     "framework-espidf": {
       "type": "framework",

--- a/platform.json
+++ b/platform.json
@@ -33,7 +33,7 @@
       "type": "framework",
       "optional": true,
       "owner": "tasmota",
-      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/1211-2052-5.5/framework-arduinoespressif32-release_v5.5-d85e5937.tar.xz"
+      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/1311-1259-5.5/framework-arduinoespressif32-release_v5.5-15833ebc.tar.xz"
     },
     "framework-espidf": {
       "type": "framework",

--- a/platform.py
+++ b/platform.py
@@ -69,7 +69,7 @@ tl_install_name = "tool-esp_install"
 
 # MCUs that support ESP-builtin debug
 ESP_BUILTIN_DEBUG_MCUS = frozenset([
-    "esp32c3", "esp32c5", "esp32c6", "esp32s3", "esp32h2", "esp32p4"
+    "esp32c3", "esp32c5", "esp32c6", "esp32c61", "esp32s3", "esp32h2", "esp32p4"
 ])
 
 # MCU configuration mapping
@@ -81,7 +81,7 @@ MCU_TOOLCHAIN_CONFIG = {
     },
     "riscv": {
         "mcus": frozenset([
-            "esp32c2", "esp32c3", "esp32c5", "esp32c6", "esp32h2", "esp32p4"
+            "esp32c2", "esp32c3", "esp32c5", "esp32c6", "esp32c61", "esp32h2", "esp32p4"
         ]),
         "toolchains": ["toolchain-riscv32-esp"],
         "debug_tools": ["tool-riscv32-esp-elf-gdb"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ESP32-C61-DevKitC-1 development board with Arduino and ESP-IDF frameworks.

* **Documentation**
  * Updated Arduino/PlatformIO compatibility requirements to Arduino 3.3.4+
  * Expanded supported ESP32 chip lineup to include ESP32-C61

<!-- end of auto-generated comment: release notes by coderabbit.ai -->