### PR TITLE
use SPIFFS python script for generating SPIFFS FS image

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -1348,15 +1348,15 @@ def download_littlefs(target, source, env):
         return 1
 
 
-def download_spiffs(_target, _source, env):
+def download_spiffs(target, source, env):
     """
     Download SPIFFS filesystem from device and extract to directory.
     Only supports SPIFFS filesystem.
     Usage: pio run -e <env> -t download_spiffs
 
     Args:
-        _target: SCons target (unused)
-        _source: SCons source (unused)
+        target: SCons target (unused)
+        source: SCons source (unused)
         env: SCons environment object
     """
     # Get unpack directory from board config or use default

--- a/builder/main.py
+++ b/builder/main.py
@@ -546,7 +546,8 @@ def build_spiffs_image(target, source, env):
     use_magic_len = True
     aligned_obj_ix_tables = False
 
-    for section in ["env:" + env["PIOENV"], "common"]:
+    # Check common section first, then env-specific (so env-specific takes precedence)
+    for section in ["common", "env:"  env["PIOENV"]]:
         if projectconfig.has_option(section, "board_build.spiffs.obj_name_len"):
             obj_name_len = int(projectconfig.get(section, "board_build.spiffs.obj_name_len"))
         if projectconfig.has_option(section, "board_build.spiffs.meta_len"):

--- a/builder/main.py
+++ b/builder/main.py
@@ -775,6 +775,20 @@ def check_lib_archive_exists():
     return False
 
 
+def build_fs_router(target, source, env):
+    """Route to appropriate filesystem builder based on filesystem type."""
+    fs_type = board.get("build.filesystem", "littlefs")
+    if fs_type == "littlefs":
+        return build_fs_image(target, source, env)
+    elif fs_type == "fatfs":
+        return build_fatfs_image(target, source, env)
+    elif fs_type == "spiffs":
+        return build_spiffs_image(target, source, env)
+    else:
+        print(f"Error: Unknown filesystem type '{fs_type}'. Supported types: littlefs, fatfs, spiffs")
+        return 1
+
+
 def switch_off_ldf():
     """
     Disables LDF (Library Dependency Finder) for uploadfs, uploadfsota, buildfs, 
@@ -893,9 +907,7 @@ env.Append(
         ),
         DataToBin=Builder(
             action=env.VerboseAction(
-                build_fs_image if filesystem == "littlefs" else (
-                    build_fatfs_image if filesystem == "fatfs" else build_spiffs_image
-                ),
+                build_fs_router,
                 "Building FS image from '$SOURCES' directory to $TARGET",
             ),
             emitter=__fetch_fs_size,

--- a/builder/main.py
+++ b/builder/main.py
@@ -842,7 +842,6 @@ env.Replace(
     ERASEFLAGS=["--chip", mcu, "--port", '"$UPLOAD_PORT"'],
     ERASETOOL=uploader_path,
     ERASECMD='$ERASETOOL $ERASEFLAGS erase-flash',
-    MKFSTOOL="mk%s" % filesystem,
 
     ESP32_FS_IMAGE_NAME=env.get(
         "ESP32_FS_IMAGE_NAME",
@@ -894,17 +893,7 @@ env.Append(
         DataToBin=Builder(
             action=env.VerboseAction(
                 build_fs_image if filesystem == "littlefs" else (
-                    build_fatfs_image if filesystem == "fatfs" else (
-                        build_spiffs_image if filesystem == "spiffs" else " ".join(
-                            ['"$MKFSTOOL"', "-c", "$SOURCES", "-s", "$FS_SIZE"]
-                            + (
-                                ["-p", "$FS_PAGE", "-b", "$FS_BLOCK"]
-                                if filesystem == "spiffs"
-                                else []
-                            )
-                            + ["$TARGET"]
-                        )
-                    )
+                    build_fatfs_image if filesystem == "fatfs" else build_spiffs_image
                 ),
                 "Building FS image from '$SOURCES' directory to $TARGET",
             ),

--- a/builder/main.py
+++ b/builder/main.py
@@ -27,13 +27,6 @@ from fatfs import Partition, RamDisk, create_extended_partition
 # Import SPIFFS generator from local module
 import sys
 import importlib.util
-spiffsgen_path = Path(__file__).parent / "spiffsgen.py"
-spec = importlib.util.spec_from_file_location("spiffsgen", spiffsgen_path)
-spiffsgen = importlib.util.module_from_spec(spec)
-sys.modules["spiffsgen"] = spiffsgen
-spec.loader.exec_module(spiffsgen)
-SpiffsFS = spiffsgen.SpiffsFS
-SpiffsBuildConfig = spiffsgen.SpiffsBuildConfig
 
 from SCons.Script import (
     ARGUMENTS,
@@ -60,6 +53,15 @@ build_dir = Path(projectconfig.get("platformio", "build_dir"))
 
 # Configure Python environment through centralized platform management
 PYTHON_EXE, esptool_binary_path = platform.setup_python_env(env)
+
+# Load SPIFFS generator from local module
+spiffsgen_path = platform_dir / "builder" / "spiffsgen.py"
+spec = importlib.util.spec_from_file_location("spiffsgen", str(spiffsgen_path))
+spiffsgen = importlib.util.module_from_spec(spec)
+sys.modules["spiffsgen"] = spiffsgen
+spec.loader.exec_module(spiffsgen)
+SpiffsFS = spiffsgen.SpiffsFS
+SpiffsBuildConfig = spiffsgen.SpiffsBuildConfig
 
 # Load board configuration and determine MCU architecture
 board = env.BoardConfig()

--- a/builder/main.py
+++ b/builder/main.py
@@ -547,7 +547,7 @@ def build_spiffs_image(target, source, env):
     aligned_obj_ix_tables = False
 
     # Check common section first, then env-specific (so env-specific takes precedence)
-    for section in ["common", "env:"  env["PIOENV"]]:
+    for section in ["common", "env:" + env["PIOENV"]]:
         if projectconfig.has_option(section, "board_build.spiffs.obj_name_len"):
             obj_name_len = int(projectconfig.get(section, "board_build.spiffs.obj_name_len"))
         if projectconfig.has_option(section, "board_build.spiffs.meta_len"):
@@ -857,7 +857,6 @@ env.Replace(
     ERASEFLAGS=["--chip", mcu, "--port", '"$UPLOAD_PORT"'],
     ERASETOOL=uploader_path,
     ERASECMD='$ERASETOOL $ERASEFLAGS erase-flash',
-
     ESP32_FS_IMAGE_NAME=env.get(
         "ESP32_FS_IMAGE_NAME",
         env.get("ESP32_SPIFFS_IMAGE_NAME", filesystem),

--- a/builder/main.py
+++ b/builder/main.py
@@ -792,12 +792,12 @@ def build_fs_router(target, source, env):
 def switch_off_ldf():
     """
     Disables LDF (Library Dependency Finder) for uploadfs, uploadfsota, buildfs, 
-    download_littlefs, download_fatfs, and erase targets.
+    download_littlefs, download_spiffs, download_fatfs, and erase targets.
 
     This optimization prevents unnecessary library dependency scanning and compilation
     when only filesystem operations are performed.
     """
-    fs_targets = {"uploadfs", "uploadfsota", "buildfs", "erase", "download_littlefs", "download_fatfs"}
+    fs_targets = {"uploadfs", "uploadfsota", "buildfs", "erase", "download_littlefs", "download_spiffs", "download_fatfs"}
     if fs_targets & set(COMMAND_LINE_TARGETS):
         # Disable LDF by modifying project configuration directly
         env_section = "env:" + env["PIOENV"]
@@ -1364,20 +1364,81 @@ def download_spiffs(_target, _source, env):
     unpack_dir = _get_unpack_dir(env)
 
     # Download partition image (SPIFFS=0x82)
-    fs_file, _fs_start, _fs_size, _fs_subtype = _download_partition_image(env, [0x82])
+    fs_file, _fs_start, fs_size, _fs_subtype = _download_partition_image(env, [0x82])
 
     if fs_file is None:
         return 1
 
     # Remove old unpack directory
-    _unpack_path = _prepare_unpack_dir(unpack_dir)
+    unpack_path = _prepare_unpack_dir(unpack_dir)
 
-    print("\nNote: SPIFFS extraction is not yet implemented.")
-    print("The filesystem image has been downloaded to:")
-    print(f"  {fs_file}")
-    print("\nYou can use external tools to extract the SPIFFS image.")
-    
-    return 0
+    try:
+        # Read the downloaded filesystem image
+        with open(fs_file, 'rb') as f:
+            fs_data = f.read()
+
+        # Get SPIFFS configuration
+        page_size = 256
+        block_size = 4096
+        obj_name_len = 32
+        meta_len = 4
+        use_magic = True
+        use_magic_len = True
+        aligned_obj_ix_tables = False
+
+        for section in ["env:" + env["PIOENV"], "common"]:
+            if projectconfig.has_option(section, "board_build.spiffs.page_size"):
+                page_size = int(projectconfig.get(section, "board_build.spiffs.page_size"))
+            if projectconfig.has_option(section, "board_build.spiffs.block_size"):
+                block_size = int(projectconfig.get(section, "board_build.spiffs.block_size"))
+            if projectconfig.has_option(section, "board_build.spiffs.obj_name_len"):
+                obj_name_len = int(projectconfig.get(section, "board_build.spiffs.obj_name_len"))
+            if projectconfig.has_option(section, "board_build.spiffs.meta_len"):
+                meta_len = int(projectconfig.get(section, "board_build.spiffs.meta_len"))
+            if projectconfig.has_option(section, "board_build.spiffs.use_magic"):
+                use_magic = projectconfig.getboolean(section, "board_build.spiffs.use_magic")
+            if projectconfig.has_option(section, "board_build.spiffs.use_magic_len"):
+                use_magic_len = projectconfig.getboolean(section, "board_build.spiffs.use_magic_len")
+            if projectconfig.has_option(section, "board_build.spiffs.aligned_obj_ix_tables"):
+                aligned_obj_ix_tables = projectconfig.getboolean(section, "board_build.spiffs.aligned_obj_ix_tables")
+
+        # Create SPIFFS build configuration
+        spiffs_build_config = SpiffsBuildConfig(
+            page_size=page_size,
+            page_ix_len=2,
+            block_size=block_size,
+            block_ix_len=2,
+            meta_len=meta_len,
+            obj_name_len=obj_name_len,
+            obj_id_len=2,
+            span_ix_len=2,
+            packed=True,
+            aligned=True,
+            endianness='little',
+            use_magic=use_magic,
+            use_magic_len=use_magic_len,
+            aligned_obj_ix_tables=aligned_obj_ix_tables
+        )
+
+        # Create SPIFFS filesystem and parse the image
+        spiffs = SpiffsFS(fs_size, spiffs_build_config)
+        spiffs.from_binary(fs_data)
+
+        # Extract files
+        print("\nExtracting files:\n")
+        file_count = spiffs.extract_files(str(unpack_path))
+
+        if file_count == 0:
+            print("\nNo files were extracted.")
+            print("The filesystem may be empty, freshly formatted, or contain only deleted entries.")
+        else:
+            print(f"\nSuccessfully extracted {file_count} file(s) to {unpack_dir}")
+
+        return 0
+
+    except Exception as e:
+        print(f"Error: Failed to extract SPIFFS filesystem: {e}")
+        return 1
 
 
 def download_fatfs(target, source, env):
@@ -1703,6 +1764,14 @@ env.AddPlatformTarget(
     None,
     download_littlefs,
     "Download and extract LittleFS filesystem from device",
+)
+
+# Target: Download SPIFFS (no build required)
+env.AddPlatformTarget(
+    "download_spiffs",
+    None,
+    download_spiffs,
+    "Download and extract SPIFFS filesystem from device",
 )
 
 # Target: Download FatFS (no build required)

--- a/builder/main.py
+++ b/builder/main.py
@@ -1349,28 +1349,28 @@ def download_littlefs(target, source, env):
         return 1
 
 
-def download_spiffs(target, source, env):
+def download_spiffs(_target, _source, env):
     """
     Download SPIFFS filesystem from device and extract to directory.
     Only supports SPIFFS filesystem.
     Usage: pio run -e <env> -t download_spiffs
 
     Args:
-        target: SCons target
-        source: SCons source
+        _target: SCons target (unused)
+        _source: SCons source (unused)
         env: SCons environment object
     """
     # Get unpack directory from board config or use default
     unpack_dir = _get_unpack_dir(env)
 
     # Download partition image (SPIFFS=0x82)
-    fs_file, fs_start, fs_size, fs_subtype = _download_partition_image(env, [0x82])
+    fs_file, _fs_start, _fs_size, _fs_subtype = _download_partition_image(env, [0x82])
 
     if fs_file is None:
         return 1
 
     # Remove old unpack directory
-    unpack_path = _prepare_unpack_dir(unpack_dir)
+    _unpack_path = _prepare_unpack_dir(unpack_dir)
 
     print("\nNote: SPIFFS extraction is not yet implemented.")
     print("The filesystem image has been downloaded to:")

--- a/builder/main.py
+++ b/builder/main.py
@@ -24,6 +24,17 @@ from pathlib import Path
 from littlefs import LittleFS
 from fatfs import Partition, RamDisk, create_extended_partition
 
+# Import SPIFFS generator from local module
+import sys
+import importlib.util
+spiffsgen_path = Path(__file__).parent / "spiffsgen.py"
+spec = importlib.util.spec_from_file_location("spiffsgen", spiffsgen_path)
+spiffsgen = importlib.util.module_from_spec(spec)
+sys.modules["spiffsgen"] = spiffsgen
+spec.loader.exec_module(spiffsgen)
+SpiffsFS = spiffsgen.SpiffsFS
+SpiffsBuildConfig = spiffsgen.SpiffsBuildConfig
+
 from SCons.Script import (
     ARGUMENTS,
     COMMAND_LINE_TARGETS,
@@ -509,6 +520,93 @@ def build_fs_image(target, source, env):
         return 1
 
 
+def build_spiffs_image(target, source, env):
+    """
+    Build SPIFFS filesystem image using spiffsgen.py.
+
+    Args:
+        target: SCons target (output .bin file)
+        source: SCons source (directory with files)
+        env: SCons environment object
+
+    Returns:
+        int: 0 on success, 1 on failure
+    """
+
+    # Get parameters
+    source_dir = str(source[0])
+    target_file = str(target[0])
+    fs_size = env["FS_SIZE"]
+    page_size = env.get("FS_PAGE", 256)
+    block_size = env.get("FS_BLOCK", 4096)
+
+    # Get SPIFFS configuration from project config or use defaults
+    obj_name_len = 32
+    meta_len = 4
+    use_magic = True
+    use_magic_len = True
+    aligned_obj_ix_tables = False
+
+    for section in ["env:" + env["PIOENV"], "common"]:
+        if projectconfig.has_option(section, "board_build.spiffs.obj_name_len"):
+            obj_name_len = int(projectconfig.get(section, "board_build.spiffs.obj_name_len"))
+        if projectconfig.has_option(section, "board_build.spiffs.meta_len"):
+            meta_len = int(projectconfig.get(section, "board_build.spiffs.meta_len"))
+        if projectconfig.has_option(section, "board_build.spiffs.use_magic"):
+            use_magic = projectconfig.getboolean(section, "board_build.spiffs.use_magic")
+        if projectconfig.has_option(section, "board_build.spiffs.use_magic_len"):
+            use_magic_len = projectconfig.getboolean(section, "board_build.spiffs.use_magic_len")
+        if projectconfig.has_option(section, "board_build.spiffs.aligned_obj_ix_tables"):
+            aligned_obj_ix_tables = projectconfig.getboolean(section, "board_build.spiffs.aligned_obj_ix_tables")
+
+    try:
+        # Create SPIFFS build configuration
+        spiffs_build_config = SpiffsBuildConfig(
+            page_size=page_size,
+            page_ix_len=2,  # SPIFFS_PAGE_IX_LEN
+            block_size=block_size,
+            block_ix_len=2,  # SPIFFS_BLOCK_IX_LEN
+            meta_len=meta_len,
+            obj_name_len=obj_name_len,
+            obj_id_len=2,  # SPIFFS_OBJ_ID_LEN
+            span_ix_len=2,  # SPIFFS_SPAN_IX_LEN
+            packed=True,
+            aligned=True,
+            endianness='little',
+            use_magic=use_magic,
+            use_magic_len=use_magic_len,
+            aligned_obj_ix_tables=aligned_obj_ix_tables
+        )
+
+        # Create SPIFFS filesystem
+        spiffs = SpiffsFS(fs_size, spiffs_build_config)
+
+        # Add all files from source directory
+        source_path = Path(source_dir)
+        if source_path.exists():
+            for item in source_path.rglob("*"):
+                if item.is_file():
+                    rel_path = item.relative_to(source_path)
+                    img_path = "/" + rel_path.as_posix()
+                    spiffs.create_file(img_path, str(item))
+
+        # Generate binary image
+        image = spiffs.to_binary()
+
+        # Write to file
+        with open(target_file, "wb") as f:
+            f.write(image)
+
+        print(f"\nSuccessfully created SPIFFS image: {target_file}")
+        return 0
+
+    except Exception as e:
+        print(f"Error building SPIFFS image: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
 def build_fatfs_image(target, source, env):
     """
     Build FatFS filesystem image with ESP32 Wear Leveling support.
@@ -801,14 +899,16 @@ env.Append(
         DataToBin=Builder(
             action=env.VerboseAction(
                 build_fs_image if filesystem == "littlefs" else (
-                    build_fatfs_image if filesystem == "fatfs" else " ".join(
-                        ['"$MKFSTOOL"', "-c", "$SOURCES", "-s", "$FS_SIZE"]
-                        + (
-                            ["-p", "$FS_PAGE", "-b", "$FS_BLOCK"]
-                            if filesystem == "spiffs"
-                            else []
+                    build_fatfs_image if filesystem == "fatfs" else (
+                        build_spiffs_image if filesystem == "spiffs" else " ".join(
+                            ['"$MKFSTOOL"', "-c", "$SOURCES", "-s", "$FS_SIZE"]
+                            + (
+                                ["-p", "$FS_PAGE", "-b", "$FS_BLOCK"]
+                                if filesystem == "spiffs"
+                                else []
+                            )
+                            + ["$TARGET"]
                         )
-                        + ["$TARGET"]
                     )
                 ),
                 "Building FS image from '$SOURCES' directory to $TARGET",
@@ -1250,6 +1350,37 @@ def download_littlefs(target, source, env):
     except Exception as e:
         print(f"Error: Failed to extract LittleFS filesystem: {e}")
         return 1
+
+
+def download_spiffs(target, source, env):
+    """
+    Download SPIFFS filesystem from device and extract to directory.
+    Only supports SPIFFS filesystem.
+    Usage: pio run -e <env> -t download_spiffs
+
+    Args:
+        target: SCons target
+        source: SCons source
+        env: SCons environment object
+    """
+    # Get unpack directory from board config or use default
+    unpack_dir = _get_unpack_dir(env)
+
+    # Download partition image (SPIFFS=0x82)
+    fs_file, fs_start, fs_size, fs_subtype = _download_partition_image(env, [0x82])
+
+    if fs_file is None:
+        return 1
+
+    # Remove old unpack directory
+    unpack_path = _prepare_unpack_dir(unpack_dir)
+
+    print("\nNote: SPIFFS extraction is not yet implemented.")
+    print("The filesystem image has been downloaded to:")
+    print(f"  {fs_file}")
+    print("\nYou can use external tools to extract the SPIFFS image.")
+    
+    return 0
 
 
 def download_fatfs(target, source, env):

--- a/builder/main.py
+++ b/builder/main.py
@@ -1385,7 +1385,7 @@ def download_spiffs(_target, _source, env):
         use_magic_len = True
         aligned_obj_ix_tables = False
 
-        for section in ["env:" + env["PIOENV"], "common"]:
+        for section in ["common", "env:" + env["PIOENV"]]:
             if projectconfig.has_option(section, "board_build.spiffs.page_size"):
                 page_size = int(projectconfig.get(section, "board_build.spiffs.page_size"))
             if projectconfig.has_option(section, "board_build.spiffs.block_size"):

--- a/builder/main.py
+++ b/builder/main.py
@@ -601,8 +601,6 @@ def build_spiffs_image(target, source, env):
 
     except Exception as e:
         print(f"Error building SPIFFS image: {e}")
-        import traceback
-        traceback.print_exc()
         return 1
 
 
@@ -760,8 +758,6 @@ def build_fatfs_image(target, source, env):
 
     except Exception as e:
         print(f"Error building FatFS image: {e}")
-        import traceback
-        traceback.print_exc()
         return 1
 
 
@@ -1481,8 +1477,6 @@ def download_fatfs(target, source, env):
 
     except Exception as e:
         print(f"Error: Failed to extract FatFS filesystem: {e}")
-        import traceback
-        traceback.print_exc()
         return 1
 
 #

--- a/builder/main.py
+++ b/builder/main.py
@@ -23,9 +23,6 @@ from os.path import isfile, join
 from pathlib import Path
 from littlefs import LittleFS
 from fatfs import Partition, RamDisk, create_extended_partition
-
-# Import SPIFFS generator from local module
-import sys
 import importlib.util
 
 from SCons.Script import (

--- a/builder/spiffsgen.py
+++ b/builder/spiffsgen.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python
+#
+# spiffsgen is a tool used to generate a spiffs image from a directory
+#
+# SPDX-FileCopyrightText: 2019-2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+import argparse
+import io
+import math
+import os
+import struct
+
+try:
+    import typing
+
+    TSP = typing.TypeVar('TSP', bound='SpiffsObjPageWithIdx')
+    ObjIdsItem = typing.Tuple[int, typing.Type[TSP]]
+except ImportError:
+    pass
+
+
+SPIFFS_PH_FLAG_USED_FINAL_INDEX = 0xF8
+SPIFFS_PH_FLAG_USED_FINAL = 0xFC
+
+SPIFFS_PH_FLAG_LEN = 1
+SPIFFS_PH_IX_SIZE_LEN = 4
+SPIFFS_PH_IX_OBJ_TYPE_LEN = 1
+SPIFFS_TYPE_FILE = 1
+
+# Based on typedefs under spiffs_config.h
+SPIFFS_OBJ_ID_LEN = 2  # spiffs_obj_id
+SPIFFS_SPAN_IX_LEN = 2  # spiffs_span_ix
+SPIFFS_PAGE_IX_LEN = 2  # spiffs_page_ix
+SPIFFS_BLOCK_IX_LEN = 2  # spiffs_block_ix
+
+
+class SpiffsBuildConfig(object):
+    def __init__(self,
+                 page_size,  # type: int
+                 page_ix_len,  # type: int
+                 block_size,  # type: int
+                 block_ix_len,  # type: int
+                 meta_len,  # type: int
+                 obj_name_len,  # type: int
+                 obj_id_len,  # type: int
+                 span_ix_len,  # type: int
+                 packed,  # type: bool
+                 aligned,  # type: bool
+                 endianness,  # type: str
+                 use_magic,  # type: bool
+                 use_magic_len,  # type: bool
+                 aligned_obj_ix_tables  # type: bool
+                 ):
+        if block_size % page_size != 0:
+            raise RuntimeError('block size should be a multiple of page size')
+
+        self.page_size = page_size
+        self.block_size = block_size
+        self.obj_id_len = obj_id_len
+        self.span_ix_len = span_ix_len
+        self.packed = packed
+        self.aligned = aligned
+        self.obj_name_len = obj_name_len
+        self.meta_len = meta_len
+        self.page_ix_len = page_ix_len
+        self.block_ix_len = block_ix_len
+        self.endianness = endianness
+        self.use_magic = use_magic
+        self.use_magic_len = use_magic_len
+        self.aligned_obj_ix_tables = aligned_obj_ix_tables
+
+        self.PAGES_PER_BLOCK = self.block_size // self.page_size
+        self.OBJ_LU_PAGES_PER_BLOCK = int(math.ceil(self.block_size / self.page_size * self.obj_id_len / self.page_size))
+        self.OBJ_USABLE_PAGES_PER_BLOCK = self.PAGES_PER_BLOCK - self.OBJ_LU_PAGES_PER_BLOCK
+
+        self.OBJ_LU_PAGES_OBJ_IDS_LIM = self.page_size // self.obj_id_len
+
+        self.OBJ_DATA_PAGE_HEADER_LEN = self.obj_id_len + self.span_ix_len + SPIFFS_PH_FLAG_LEN
+
+        pad = 4 - (4 if self.OBJ_DATA_PAGE_HEADER_LEN % 4 == 0 else self.OBJ_DATA_PAGE_HEADER_LEN % 4)
+
+        self.OBJ_DATA_PAGE_HEADER_LEN_ALIGNED = self.OBJ_DATA_PAGE_HEADER_LEN + pad
+        self.OBJ_DATA_PAGE_HEADER_LEN_ALIGNED_PAD = pad
+        self.OBJ_DATA_PAGE_CONTENT_LEN = self.page_size - self.OBJ_DATA_PAGE_HEADER_LEN
+
+        self.OBJ_INDEX_PAGES_HEADER_LEN = (self.OBJ_DATA_PAGE_HEADER_LEN_ALIGNED + SPIFFS_PH_IX_SIZE_LEN +
+                                           SPIFFS_PH_IX_OBJ_TYPE_LEN + self.obj_name_len + self.meta_len)
+        if aligned_obj_ix_tables:
+            self.OBJ_INDEX_PAGES_HEADER_LEN_ALIGNED = (self.OBJ_INDEX_PAGES_HEADER_LEN + SPIFFS_PAGE_IX_LEN - 1) & ~(SPIFFS_PAGE_IX_LEN - 1)
+            self.OBJ_INDEX_PAGES_HEADER_LEN_ALIGNED_PAD = self.OBJ_INDEX_PAGES_HEADER_LEN_ALIGNED - self.OBJ_INDEX_PAGES_HEADER_LEN
+        else:
+            self.OBJ_INDEX_PAGES_HEADER_LEN_ALIGNED = self.OBJ_INDEX_PAGES_HEADER_LEN
+            self.OBJ_INDEX_PAGES_HEADER_LEN_ALIGNED_PAD = 0
+
+        self.OBJ_INDEX_PAGES_OBJ_IDS_HEAD_LIM = (self.page_size - self.OBJ_INDEX_PAGES_HEADER_LEN_ALIGNED) // self.block_ix_len
+        self.OBJ_INDEX_PAGES_OBJ_IDS_LIM = (self.page_size - self.OBJ_DATA_PAGE_HEADER_LEN_ALIGNED) // self.block_ix_len
+
+
+class SpiffsFullError(RuntimeError):
+    pass
+
+
+class SpiffsPage(object):
+    _endianness_dict = {
+        'little': '<',
+        'big': '>'
+    }
+
+    _len_dict = {
+        1: 'B',
+        2: 'H',
+        4: 'I',
+        8: 'Q'
+    }
+
+    def __init__(self, bix, build_config):  # type: (int, SpiffsBuildConfig) -> None
+        self.build_config = build_config
+        self.bix = bix
+
+    def to_binary(self):  # type: () -> bytes
+        raise NotImplementedError()
+
+
+class SpiffsObjPageWithIdx(SpiffsPage):
+    def __init__(self, obj_id, build_config):  # type: (int, SpiffsBuildConfig) -> None
+        super(SpiffsObjPageWithIdx, self).__init__(0, build_config)
+        self.obj_id = obj_id
+
+    def to_binary(self):  # type: () -> bytes
+        raise NotImplementedError()
+
+
+class SpiffsObjLuPage(SpiffsPage):
+    def __init__(self, bix, build_config):  # type: (int, SpiffsBuildConfig) -> None
+        SpiffsPage.__init__(self, bix, build_config)
+
+        self.obj_ids_limit = self.build_config.OBJ_LU_PAGES_OBJ_IDS_LIM
+        self.obj_ids = list()  # type: typing.List[ObjIdsItem]
+
+    def _calc_magic(self, blocks_lim):  # type: (int) -> int
+        # Calculate the magic value mirroring computation done by the macro SPIFFS_MAGIC defined in
+        # spiffs_nucleus.h
+        magic = 0x20140529 ^ self.build_config.page_size
+        if self.build_config.use_magic_len:
+            magic = magic ^ (blocks_lim - self.bix)
+        # narrow the result to build_config.obj_id_len bytes
+        mask = (2 << (8 * self.build_config.obj_id_len)) - 1
+        return magic & mask
+
+    def register_page(self, page):  # type: (TSP) -> None
+        if not self.obj_ids_limit > 0:
+            raise SpiffsFullError()
+
+        obj_id = (page.obj_id, page.__class__)
+        self.obj_ids.append(obj_id)
+        self.obj_ids_limit -= 1
+
+    def to_binary(self):  # type: () -> bytes
+        img = b''
+
+        for (obj_id, page_type) in self.obj_ids:
+            if page_type == SpiffsObjIndexPage:
+                obj_id ^= (1 << ((self.build_config.obj_id_len * 8) - 1))
+            img += struct.pack(SpiffsPage._endianness_dict[self.build_config.endianness] +
+                               SpiffsPage._len_dict[self.build_config.obj_id_len], obj_id)
+
+        assert len(img) <= self.build_config.page_size
+
+        img += b'\xFF' * (self.build_config.page_size - len(img))
+
+        return img
+
+    def magicfy(self, blocks_lim):  # type: (int) -> None
+        # Only use magic value if no valid obj id has been written to the spot, which is the
+        # spot taken up by the last obj id on last lookup page. The parent is responsible
+        # for determining which is the last lookup page and calling this function.
+        remaining = self.obj_ids_limit
+        empty_obj_id_dict = {
+            1: 0xFF,
+            2: 0xFFFF,
+            4: 0xFFFFFFFF,
+            8: 0xFFFFFFFFFFFFFFFF
+        }
+        if remaining >= 2:
+            for i in range(remaining):
+                if i == remaining - 2:
+                    self.obj_ids.append((self._calc_magic(blocks_lim), SpiffsObjDataPage))
+                    break
+                else:
+                    self.obj_ids.append((empty_obj_id_dict[self.build_config.obj_id_len], SpiffsObjDataPage))
+                self.obj_ids_limit -= 1
+
+
+class SpiffsObjIndexPage(SpiffsObjPageWithIdx):
+    def __init__(self, obj_id, span_ix, size, name, build_config
+                 ):  # type: (int, int, int, str, SpiffsBuildConfig) -> None
+        super(SpiffsObjIndexPage, self).__init__(obj_id, build_config)
+        self.span_ix = span_ix
+        self.name = name
+        self.size = size
+
+        if self.span_ix == 0:
+            self.pages_lim = self.build_config.OBJ_INDEX_PAGES_OBJ_IDS_HEAD_LIM
+        else:
+            self.pages_lim = self.build_config.OBJ_INDEX_PAGES_OBJ_IDS_LIM
+
+        self.pages = list()  # type: typing.List[int]
+
+    def register_page(self, page):  # type: (SpiffsObjDataPage) -> None
+        if not self.pages_lim > 0:
+            raise SpiffsFullError
+
+        self.pages.append(page.offset)
+        self.pages_lim -= 1
+
+    def to_binary(self):  # type: () -> bytes
+        obj_id = self.obj_id ^ (1 << ((self.build_config.obj_id_len * 8) - 1))
+        img = struct.pack(SpiffsPage._endianness_dict[self.build_config.endianness] +
+                          SpiffsPage._len_dict[self.build_config.obj_id_len] +
+                          SpiffsPage._len_dict[self.build_config.span_ix_len] +
+                          SpiffsPage._len_dict[SPIFFS_PH_FLAG_LEN],
+                          obj_id,
+                          self.span_ix,
+                          SPIFFS_PH_FLAG_USED_FINAL_INDEX)
+
+        # Add padding before the object index page specific information
+        img += b'\xFF' * self.build_config.OBJ_DATA_PAGE_HEADER_LEN_ALIGNED_PAD
+
+        # If this is the first object index page for the object, add filename, type
+        # and size information
+        if self.span_ix == 0:
+            img += struct.pack(SpiffsPage._endianness_dict[self.build_config.endianness] +
+                               SpiffsPage._len_dict[SPIFFS_PH_IX_SIZE_LEN]  +
+                               SpiffsPage._len_dict[SPIFFS_PH_FLAG_LEN],
+                               self.size,
+                               SPIFFS_TYPE_FILE)
+
+            img += self.name.encode() + (b'\x00' * (
+                (self.build_config.obj_name_len - len(self.name))
+                + self.build_config.meta_len
+                + self.build_config.OBJ_INDEX_PAGES_HEADER_LEN_ALIGNED_PAD))
+
+        # Finally, add the page index of data pages
+        for page in self.pages:
+            page = page >> int(math.log(self.build_config.page_size, 2))
+            img += struct.pack(SpiffsPage._endianness_dict[self.build_config.endianness] +
+                               SpiffsPage._len_dict[self.build_config.page_ix_len], page)
+
+        assert len(img) <= self.build_config.page_size
+
+        img += b'\xFF' * (self.build_config.page_size - len(img))
+
+        return img
+
+
+class SpiffsObjDataPage(SpiffsObjPageWithIdx):
+    def __init__(self, offset, obj_id, span_ix, contents, build_config
+                 ):  # type: (int, int, int, bytes, SpiffsBuildConfig) -> None
+        super(SpiffsObjDataPage, self).__init__(obj_id, build_config)
+        self.span_ix = span_ix
+        self.contents = contents
+        self.offset = offset
+
+    def to_binary(self):  # type: () -> bytes
+        img = struct.pack(SpiffsPage._endianness_dict[self.build_config.endianness] +
+                          SpiffsPage._len_dict[self.build_config.obj_id_len] +
+                          SpiffsPage._len_dict[self.build_config.span_ix_len] +
+                          SpiffsPage._len_dict[SPIFFS_PH_FLAG_LEN],
+                          self.obj_id,
+                          self.span_ix,
+                          SPIFFS_PH_FLAG_USED_FINAL)
+
+        img += self.contents
+
+        assert len(img) <= self.build_config.page_size
+
+        img += b'\xFF' * (self.build_config.page_size - len(img))
+
+        return img
+
+
+class SpiffsBlock(object):
+    def _reset(self):  # type: () -> None
+        self.cur_obj_index_span_ix = 0
+        self.cur_obj_data_span_ix = 0
+        self.cur_obj_id = 0
+        self.cur_obj_idx_page = None  # type: typing.Optional[SpiffsObjIndexPage]
+
+    def __init__(self, bix, build_config):  # type: (int, SpiffsBuildConfig) -> None
+        self.build_config = build_config
+        self.offset = bix * self.build_config.block_size
+        self.remaining_pages = self.build_config.OBJ_USABLE_PAGES_PER_BLOCK
+        self.pages = list()  # type: typing.List[SpiffsPage]
+        self.bix = bix
+
+        lu_pages = list()
+        for i in range(self.build_config.OBJ_LU_PAGES_PER_BLOCK):
+            page = SpiffsObjLuPage(self.bix, self.build_config)
+            lu_pages.append(page)
+
+        self.pages.extend(lu_pages)
+
+        self.lu_page_iter = iter(lu_pages)
+        self.lu_page = next(self.lu_page_iter)
+
+        self._reset()
+
+    def _register_page(self, page):  # type: (TSP) -> None
+        if isinstance(page, SpiffsObjDataPage):
+            assert self.cur_obj_idx_page is not None
+            self.cur_obj_idx_page.register_page(page)  # can raise SpiffsFullError
+
+        try:
+            self.lu_page.register_page(page)
+        except SpiffsFullError:
+            self.lu_page = next(self.lu_page_iter)
+            try:
+                self.lu_page.register_page(page)
+            except AttributeError:  # no next lookup page
+                # Since the amount of lookup pages is pre-computed at every block instance,
+                # this should never occur
+                raise RuntimeError('invalid attempt to add page to a block when there is no more space in lookup')
+
+        self.pages.append(page)
+
+    def begin_obj(self, obj_id, size, name, obj_index_span_ix=0, obj_data_span_ix=0
+                  ):  # type: (int, int, str, int, int) -> None
+        if not self.remaining_pages > 0:
+            raise SpiffsFullError()
+        self._reset()
+
+        self.cur_obj_id = obj_id
+        self.cur_obj_index_span_ix = obj_index_span_ix
+        self.cur_obj_data_span_ix = obj_data_span_ix
+
+        page = SpiffsObjIndexPage(obj_id, self.cur_obj_index_span_ix, size, name, self.build_config)
+        self._register_page(page)
+
+        self.cur_obj_idx_page = page
+
+        self.remaining_pages -= 1
+        self.cur_obj_index_span_ix += 1
+
+    def update_obj(self, contents):  # type: (bytes) -> None
+        if not self.remaining_pages > 0:
+            raise SpiffsFullError()
+        page = SpiffsObjDataPage(self.offset + (len(self.pages) * self.build_config.page_size),
+                                 self.cur_obj_id, self.cur_obj_data_span_ix, contents, self.build_config)
+
+        self._register_page(page)
+
+        self.cur_obj_data_span_ix += 1
+        self.remaining_pages -= 1
+
+    def end_obj(self):  # type: () -> None
+        self._reset()
+
+    def is_full(self):  # type: () -> bool
+        return self.remaining_pages <= 0
+
+    def to_binary(self, blocks_lim):  # type: (int) -> bytes
+        img = b''
+
+        if self.build_config.use_magic:
+            for (idx, page) in enumerate(self.pages):
+                if idx == self.build_config.OBJ_LU_PAGES_PER_BLOCK - 1:
+                    assert isinstance(page, SpiffsObjLuPage)
+                    page.magicfy(blocks_lim)
+                img += page.to_binary()
+        else:
+            for page in self.pages:
+                img += page.to_binary()
+
+        assert len(img) <= self.build_config.block_size
+
+        img += b'\xFF' * (self.build_config.block_size - len(img))
+        return img
+
+
+class SpiffsFS(object):
+    def __init__(self, img_size, build_config):  # type: (int, SpiffsBuildConfig) -> None
+        if img_size % build_config.block_size != 0:
+            raise RuntimeError('image size should be a multiple of block size')
+
+        self.img_size = img_size
+        self.build_config = build_config
+
+        self.blocks = list()  # type: typing.List[SpiffsBlock]
+        self.blocks_lim = self.img_size // self.build_config.block_size
+        self.remaining_blocks = self.blocks_lim
+        self.cur_obj_id = 1  # starting object id
+
+    def _create_block(self):  # type: () -> SpiffsBlock
+        if self.is_full():
+            raise SpiffsFullError('the image size has been exceeded')
+
+        block = SpiffsBlock(len(self.blocks), self.build_config)
+        self.blocks.append(block)
+        self.remaining_blocks -= 1
+        return block
+
+    def is_full(self):  # type: () -> bool
+        return self.remaining_blocks <= 0
+
+    def create_file(self, img_path, file_path):  # type: (str, str) -> None
+        if len(img_path) > self.build_config.obj_name_len:
+            raise RuntimeError("object name '%s' too long" % img_path)
+
+        name = img_path
+
+        with open(file_path, 'rb') as obj:
+            contents = obj.read()
+
+        stream = io.BytesIO(contents)
+
+        try:
+            block = self.blocks[-1]
+            block.begin_obj(self.cur_obj_id, len(contents), name)
+        except (IndexError, SpiffsFullError):
+            block = self._create_block()
+            block.begin_obj(self.cur_obj_id, len(contents), name)
+
+        contents_chunk = stream.read(self.build_config.OBJ_DATA_PAGE_CONTENT_LEN)
+
+        while contents_chunk:
+            try:
+                block = self.blocks[-1]
+                try:
+                    # This can fail because either (1) all the pages in block have been
+                    # used or (2) object index has been exhausted.
+                    block.update_obj(contents_chunk)
+                except SpiffsFullError:
+                    # If its (1), use the outer exception handler
+                    if block.is_full():
+                        raise SpiffsFullError
+                    # If its (2), write another object index page
+                    block.begin_obj(self.cur_obj_id, len(contents), name,
+                                    obj_index_span_ix=block.cur_obj_index_span_ix,
+                                    obj_data_span_ix=block.cur_obj_data_span_ix)
+                    continue
+            except (IndexError, SpiffsFullError):
+                # All pages in the block have been exhausted. Create a new block, copying
+                # the previous state of the block to a new one for the continuation of the
+                # current object
+                prev_block = block
+                block = self._create_block()
+                block.cur_obj_id = prev_block.cur_obj_id
+                block.cur_obj_idx_page = prev_block.cur_obj_idx_page
+                block.cur_obj_data_span_ix = prev_block.cur_obj_data_span_ix
+                block.cur_obj_index_span_ix = prev_block.cur_obj_index_span_ix
+                continue
+
+            contents_chunk = stream.read(self.build_config.OBJ_DATA_PAGE_CONTENT_LEN)
+
+        block.end_obj()
+
+        self.cur_obj_id += 1
+
+    def to_binary(self):  # type: () -> bytes
+        img = b''
+        all_blocks = []
+        for block in self.blocks:
+            all_blocks.append(block.to_binary(self.blocks_lim))
+        bix = len(self.blocks)
+        if self.build_config.use_magic:
+            # Create empty blocks with magic numbers
+            while self.remaining_blocks > 0:
+                block = SpiffsBlock(bix, self.build_config)
+                all_blocks.append(block.to_binary(self.blocks_lim))
+                self.remaining_blocks -= 1
+                bix += 1
+        else:
+            # Just fill remaining spaces FF's
+            all_blocks.append(b'\xFF' * (self.img_size - len(all_blocks) * self.build_config.block_size))
+        img += b''.join([blk for blk in all_blocks])
+        return img
+
+
+class CustomHelpFormatter(argparse.HelpFormatter):
+    """
+    Similar to argparse.ArgumentDefaultsHelpFormatter, except it
+    doesn't add the default value if "(default:" is already present.
+    This helps in the case of options with action="store_false", like
+    --no-magic or --no-magic-len.
+    """
+    def _get_help_string(self, action):  # type: (argparse.Action) -> str
+        if action.help is None:
+            return ''
+        if '%(default)' not in action.help and '(default:' not in action.help:
+            if action.default is not argparse.SUPPRESS:
+                defaulting_nargs = [argparse.OPTIONAL, argparse.ZERO_OR_MORE]
+                if action.option_strings or action.nargs in defaulting_nargs:
+                    return action.help + ' (default: %(default)s)'
+        return action.help
+
+
+def main():  # type: () -> None
+    parser = argparse.ArgumentParser(description='SPIFFS Image Generator',
+                                     formatter_class=CustomHelpFormatter)
+
+    parser.add_argument('image_size',
+                        help='Size of the created image')
+
+    parser.add_argument('base_dir',
+                        help='Path to directory from which the image will be created')
+
+    parser.add_argument('output_file',
+                        help='Created image output file path')
+
+    parser.add_argument('--page-size',
+                        help='Logical page size. Set to value same as CONFIG_SPIFFS_PAGE_SIZE.',
+                        type=int,
+                        default=256)
+
+    parser.add_argument('--block-size',
+                        help="Logical block size. Set to the same value as the flash chip's sector size (g_rom_flashchip.sector_size).",
+                        type=int,
+                        default=4096)
+
+    parser.add_argument('--obj-name-len',
+                        help='File full path maximum length. Set to value same as CONFIG_SPIFFS_OBJ_NAME_LEN.',
+                        type=int,
+                        default=32)
+
+    parser.add_argument('--meta-len',
+                        help='File metadata length. Set to value same as CONFIG_SPIFFS_META_LENGTH.',
+                        type=int,
+                        default=4)
+
+    parser.add_argument('--use-magic',
+                        dest='use_magic',
+                        help='Use magic number to create an identifiable SPIFFS image. Specify if CONFIG_SPIFFS_USE_MAGIC.',
+                        action='store_true')
+
+    parser.add_argument('--no-magic',
+                        dest='use_magic',
+                        help='Inverse of --use-magic (default: --use-magic is enabled)',
+                        action='store_false')
+
+    parser.add_argument('--use-magic-len',
+                        dest='use_magic_len',
+                        help='Use position in memory to create different magic numbers for each block. Specify if CONFIG_SPIFFS_USE_MAGIC_LENGTH.',
+                        action='store_true')
+
+    parser.add_argument('--no-magic-len',
+                        dest='use_magic_len',
+                        help='Inverse of --use-magic-len (default: --use-magic-len is enabled)',
+                        action='store_false')
+
+    parser.add_argument('--follow-symlinks',
+                        help='Take into account symbolic links during partition image creation.',
+                        action='store_true')
+
+    parser.add_argument('--big-endian',
+                        help='Specify if the target architecture is big-endian. If not specified, little-endian is assumed.',
+                        action='store_true')
+
+    parser.add_argument('--aligned-obj-ix-tables',
+                        action='store_true',
+                        help='Use aligned object index tables. Specify if SPIFFS_ALIGNED_OBJECT_INDEX_TABLES is set.')
+
+    parser.set_defaults(use_magic=True, use_magic_len=True)
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.base_dir):
+        raise RuntimeError('given base directory %s does not exist' % args.base_dir)
+
+    with open(args.output_file, 'wb') as image_file:
+        image_size = int(args.image_size, 0)
+        spiffs_build_default = SpiffsBuildConfig(args.page_size, SPIFFS_PAGE_IX_LEN,
+                                                 args.block_size, SPIFFS_BLOCK_IX_LEN, args.meta_len,
+                                                 args.obj_name_len, SPIFFS_OBJ_ID_LEN, SPIFFS_SPAN_IX_LEN,
+                                                 True, True, 'big' if args.big_endian else 'little',
+                                                 args.use_magic, args.use_magic_len, args.aligned_obj_ix_tables)
+
+        spiffs = SpiffsFS(image_size, spiffs_build_default)
+
+        for root, dirs, files in os.walk(args.base_dir, followlinks=args.follow_symlinks):
+            for f in files:
+                full_path = os.path.join(root, f)
+                spiffs.create_file('/' + os.path.relpath(full_path, args.base_dir).replace('\\', '/'), full_path)
+
+        image = spiffs.to_binary()
+
+        image_file.write(image)
+
+
+if __name__ == '__main__':
+    main()

--- a/builder/spiffsgen.py
+++ b/builder/spiffsgen.py
@@ -620,6 +620,9 @@ class SpiffsFS(object):
             # Remove leading slash if present
             rel_path = file_info['name'].lstrip('/')
             file_path = os.path.join(output_dir, rel_path)
+            if not rel_path:
+                print(f"  Warning: Skipping file with empty path (obj_id={obj_id})")
+                continue
 
             # Create parent directories
             os.makedirs(os.path.dirname(file_path), exist_ok=True)

--- a/builder/spiffsgen.py
+++ b/builder/spiffsgen.py
@@ -376,6 +376,14 @@ class SpiffsBlock(object):
         img += b'\xFF' * (self.build_config.block_size - len(img))
         return img
 
+    def _parse_from_binary(self, block_data):  # type: (bytes) -> None
+        """Parse block data from binary image.
+        
+        Args:
+            block_data: Raw block bytes
+        """
+        self._raw_data = block_data
+
 
 class SpiffsFS(object):
     def __init__(self, img_size, build_config):  # type: (int, SpiffsBuildConfig) -> None
@@ -474,6 +482,167 @@ class SpiffsFS(object):
             all_blocks.append(b'\xFF' * (self.img_size - len(all_blocks) * self.build_config.block_size))
         img += b''.join([blk for blk in all_blocks])
         return img
+
+    def from_binary(self, image_data):  # type: (bytes) -> None
+        """Parse a SPIFFS binary image and populate the filesystem structure.
+
+        Args:
+            image_data: Raw SPIFFS image bytes
+        """
+        if len(image_data) != self.img_size:
+            raise RuntimeError(f'image size mismatch: expected {self.img_size}, got {len(image_data)}')
+
+        # Parse blocks from the image
+        blocks_count = self.img_size // self.build_config.block_size
+        for bix in range(blocks_count):
+            block_offset = bix * self.build_config.block_size
+            block_data = image_data[block_offset:block_offset + self.build_config.block_size]
+            block = SpiffsBlock(bix, self.build_config)
+            block._parse_from_binary(block_data)
+            self.blocks.append(block)
+
+    def extract_files(self, output_dir):  # type: (str) -> int
+        """Extract all files from the SPIFFS filesystem to a directory.
+
+        Args:
+            output_dir: Directory path where files will be extracted
+
+        Returns:
+            int: Number of files extracted
+        """
+
+        # Build a map of object_id -> file info
+        files_map = {}  # obj_id -> {'name': str, 'size': int, 'data_pages': [(span_ix, page_data)]}
+
+        for block in self.blocks:
+            # Parse lookup pages to find valid objects
+            for page_idx in range(self.build_config.OBJ_LU_PAGES_PER_BLOCK):
+                lu_page_offset = page_idx * self.build_config.page_size
+                lu_page_data = block._raw_data[lu_page_offset:lu_page_offset + self.build_config.page_size]
+
+                # Parse object IDs from lookup page
+                for i in range(0, len(lu_page_data), self.build_config.obj_id_len):
+                    if i + self.build_config.obj_id_len > len(lu_page_data):
+                        break
+
+                    obj_id_bytes = lu_page_data[i:i + self.build_config.obj_id_len]
+                    obj_id = struct.unpack(
+                        SpiffsPage._endianness_dict[self.build_config.endianness] +
+                        SpiffsPage._len_dict[self.build_config.obj_id_len],
+                        obj_id_bytes
+                    )[0]
+
+                    # Check if it's a valid object (not erased/empty)
+                    empty_values = {1: 0xFF, 2: 0xFFFF, 4: 0xFFFFFFFF, 8: 0xFFFFFFFFFFFFFFFF}
+                    if obj_id == empty_values[self.build_config.obj_id_len]:
+                        continue
+
+                    # Check if it's an index page (MSB set)
+                    is_index = obj_id & (1 << ((self.build_config.obj_id_len * 8) - 1))
+                    real_obj_id = obj_id & ~(1 << ((self.build_config.obj_id_len * 8) - 1))
+
+                    if is_index and real_obj_id not in files_map:
+                        files_map[real_obj_id] = {'name': None, 'size': 0, 'data_pages': []}
+
+            # Parse actual pages to get file metadata and content
+            for page_idx in range(self.build_config.OBJ_LU_PAGES_PER_BLOCK, self.build_config.PAGES_PER_BLOCK):
+                page_offset = page_idx * self.build_config.page_size
+                page_data = block._raw_data[page_offset:page_offset + self.build_config.page_size]
+
+                # Parse page header
+                header_fmt = (
+                    SpiffsPage._endianness_dict[self.build_config.endianness] +
+                    SpiffsPage._len_dict[self.build_config.obj_id_len] +
+                    SpiffsPage._len_dict[self.build_config.span_ix_len] +
+                    SpiffsPage._len_dict[SPIFFS_PH_FLAG_LEN]
+                )
+                header_size = struct.calcsize(header_fmt)
+
+                if len(page_data) < header_size:
+                    continue
+
+                obj_id, span_ix, flags = struct.unpack(header_fmt, page_data[:header_size])
+
+                # Check for valid page
+                empty_id = {1: 0xFF, 2: 0xFFFF, 4: 0xFFFFFFFF, 8: 0xFFFFFFFFFFFFFFFF}[self.build_config.obj_id_len]
+                if obj_id == empty_id:
+                    continue
+
+                is_index = obj_id & (1 << ((self.build_config.obj_id_len * 8) - 1))
+                real_obj_id = obj_id & ~(1 << ((self.build_config.obj_id_len * 8) - 1))
+
+                if is_index and flags == SPIFFS_PH_FLAG_USED_FINAL_INDEX:
+                    # Index page - contains file metadata
+                    if real_obj_id not in files_map:
+                        files_map[real_obj_id] = {'name': None, 'size': 0, 'data_pages': []}
+
+                    # Only first index page (span_ix == 0) has filename and size
+                    if span_ix == 0:
+                        # Skip to size and type fields
+                        offset = header_size + self.build_config.OBJ_DATA_PAGE_HEADER_LEN_ALIGNED_PAD
+                        size_type_fmt = (
+                            SpiffsPage._endianness_dict[self.build_config.endianness] +
+                            SpiffsPage._len_dict[SPIFFS_PH_IX_SIZE_LEN] +
+                            SpiffsPage._len_dict[SPIFFS_PH_IX_OBJ_TYPE_LEN]
+                        )
+                        size_type_size = struct.calcsize(size_type_fmt)
+
+                        if offset + size_type_size <= len(page_data):
+                            file_size, obj_type = struct.unpack(size_type_fmt, page_data[offset:offset + size_type_size])
+                            offset += size_type_size
+
+                            # Read filename
+                            name_end = offset + self.build_config.obj_name_len
+                            if name_end <= len(page_data):
+                                name_bytes = page_data[offset:name_end]
+                                # Find null terminator
+                                null_pos = name_bytes.find(b'\x00')
+                                if null_pos != -1:
+                                    name_bytes = name_bytes[:null_pos]
+                                filename = name_bytes.decode('utf-8', errors='ignore')
+                                files_map[real_obj_id]['name'] = filename
+                                files_map[real_obj_id]['size'] = file_size
+
+                elif not is_index and flags == SPIFFS_PH_FLAG_USED_FINAL:
+                    # Data page - contains file content
+                    if real_obj_id in files_map:
+                        # Extract content (skip header, no padding on data pages)
+                        content_start = header_size
+                        content = page_data[content_start:content_start + self.build_config.OBJ_DATA_PAGE_CONTENT_LEN]
+                        files_map[real_obj_id]['data_pages'].append((span_ix, content))
+
+        # Extract files to output directory
+        file_count = 0
+        for obj_id, file_info in files_map.items():
+            if file_info['name'] is None:
+                continue
+
+            # Remove leading slash if present
+            rel_path = file_info['name'].lstrip('/')
+            file_path = os.path.join(output_dir, rel_path)
+
+            # Create parent directories
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+            # Sort data pages by span index
+            file_info['data_pages'].sort(key=lambda x: x[0])
+
+            # Write file content
+            with open(file_path, 'wb') as f:
+                total_written = 0
+                for span_ix, content in file_info['data_pages']:
+                    # Write only up to the file size
+                    remaining = file_info['size'] - total_written
+                    if remaining <= 0:
+                        break
+                    to_write = min(len(content), remaining)
+                    f.write(content[:to_write])
+                    total_written += to_write
+
+            file_count += 1
+            print(f"  Extracted: {file_info['name']} ({file_info['size']} bytes)")
+
+        return file_count
 
 
 class CustomHelpFormatter(argparse.HelpFormatter):

--- a/builder/spiffsgen.py
+++ b/builder/spiffsgen.py
@@ -208,7 +208,7 @@ class SpiffsObjIndexPage(SpiffsObjPageWithIdx):
 
     def register_page(self, page):  # type: (SpiffsObjDataPage) -> None
         if not self.pages_lim > 0:
-            raise SpiffsFullError
+            raise SpiffsFullError()
 
         self.pages.append(page.offset)
         self.pages_lim -= 1

--- a/platform.py
+++ b/platform.py
@@ -740,7 +740,6 @@ class Espressif32Platform(PlatformBase):
 
             self._configure_rom_elfs_for_exception_decoder(variables)
             self._configure_check_tools(variables)
-            self._configure_filesystem_tools(variables, targets)
 
             logger.info("Package configuration completed successfully")
 

--- a/platform.py
+++ b/platform.py
@@ -696,20 +696,6 @@ class Espressif32Platform(PlatformBase):
             if any(tool in package for tool in check_tools):
                 self.install_tool(package)
 
-    def _install_filesystem_tool(self, filesystem: str) -> None:
-        """Install filesystem-specific tools based on the filesystem type."""
-        # LittleFS and FatFS are handled by Python modules (littlefs-python, fatfs-python)
-        # Only install tools for other filesystems
-        if filesystem == "spiffs":
-            self.install_tool("tool-mkspiffs")
-
-    def _configure_filesystem_tools(self, variables: Dict, targets: List[str]) -> None:
-        """Configure filesystem tools based on build targets and filesystem type."""
-        filesystem = variables.get("board_build.filesystem", "littlefs")
-
-        if any(target in targets for target in ["buildfs", "uploadfs", "downloadfs"]):
-            self._install_filesystem_tool(filesystem)
-
     def setup_python_env(self, env):
         """Configure SCons environment with centrally managed Python executable paths."""
         # Python environment is centrally managed in configure_default_packages


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add full SPIFFS support: build configurable SPIFFS images, CLI image generator, and download+extract SPIFFS contents from devices.

* **Refactor**
  * Unified filesystem build routing so SPIFFS, LittleFS and FAT follow the same build path.
  * Simplified platform setup by removing filesystem-specific tool installation/configuration.

* **Bug Fixes**
  * Aligned filesystem build error handling for more consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->