### PR TITLE
Fix: espidf build

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1418,28 +1418,32 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
                         extra = ""
                 else:
                     parts = rest.split(None, 1)
+                    if not parts:
+                        # malformed response-file fragment (e.g. "@")
+                        continue
                     resp_path = parts[0]
                     extra = parts[1] if len(parts) > 1 else ""
 
                 # Try to resolve response file path
                 resolved_resp_path = None
-                if os.path.isfile(resp_path):
-                    resolved_resp_path = resp_path
-                elif not os.path.isabs(resp_path):
-                    # Try relative to BUILD_DIR
+                if os.path.isabs(resp_path):
+                    if os.path.isfile(resp_path):
+                        resolved_resp_path = resp_path
+                else:
+                    # Prefer BUILD_DIR-relative resolution for response files from CMake/Ninja
                     candidate = os.path.join(BUILD_DIR, resp_path)
                     if os.path.isfile(candidate):
                         resolved_resp_path = candidate
+                    elif os.path.isfile(resp_path):
+                        # fallback for legacy cwd-relative cases
+                        resolved_resp_path = resp_path
 
                 if resolved_resp_path:
-                    with open(resolved_resp_path, "r") as rf:
+                    with open(resolved_resp_path, "r", encoding="utf-8") as rf:
                         expanded = rf.read().replace("\n", " ").strip()
                     build_flags = (expanded + " " + extra).strip() if extra else expanded
                 else:
-                    # Response file not found - preserve extra flags and log warning
-                    sys.stderr.write(
-                        f"Warning: Response file not found: {resp_path}\n"
-                    )
+                    # Response file not found - preserve extra flags
                     if extra:
                         build_flags = extra
                     else:

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1404,10 +1404,24 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
             if build_flags.startswith('"') and build_flags.endswith('"'):
                 build_flags = build_flags[1:-1]
             if build_flags.startswith("@"):
-                resp_path = build_flags[1:].strip('" ')
+                # Parse @"path" or @path, possibly followed by extra flags
+                rest = build_flags[1:]
+                if rest.startswith('"'):
+                    end_quote = rest.find('"', 1)
+                    if end_quote != -1:
+                        resp_path = rest[1:end_quote]
+                        extra = rest[end_quote + 1:].strip()
+                    else:
+                        resp_path = rest.strip('" ')
+                        extra = ""
+                else:
+                    parts = rest.split(None, 1)
+                    resp_path = parts[0]
+                    extra = parts[1] if len(parts) > 1 else ""
                 if os.path.isfile(resp_path):
                     with open(resp_path, "r") as rf:
-                        build_flags = rf.read().replace("\n", " ").strip()
+                        expanded = rf.read().replace("\n", " ").strip()
+                    build_flags = (expanded + " " + extra).strip() if extra else expanded
                 else:
                     continue
             if not build_flags.startswith("-D"):

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1418,12 +1418,31 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
                     parts = rest.split(None, 1)
                     resp_path = parts[0]
                     extra = parts[1] if len(parts) > 1 else ""
+
+                # Try to resolve response file path
+                resolved_resp_path = None
                 if os.path.isfile(resp_path):
-                    with open(resp_path, "r") as rf:
+                    resolved_resp_path = resp_path
+                elif not os.path.isabs(resp_path):
+                    # Try relative to BUILD_DIR
+                    candidate = os.path.join(BUILD_DIR, resp_path)
+                    if os.path.isfile(candidate):
+                        resolved_resp_path = candidate
+
+                if resolved_resp_path:
+                    with open(resolved_resp_path, "r") as rf:
                         expanded = rf.read().replace("\n", " ").strip()
                     build_flags = (expanded + " " + extra).strip() if extra else expanded
                 else:
-                    continue
+                    # Response file not found - preserve extra flags and log warning
+                    sys.stderr.write(
+                        f"Warning: Response file not found: {resp_path}\n"
+                    )
+                    if extra:
+                        build_flags = extra
+                    else:
+                        # No extra flags, skip this fragment entirely
+                        continue
             if not build_flags.startswith("-D"):
                 if build_flags.startswith("-include") and ".." in build_flags:
                     source_index = cg.get("sourceIndexes")[0]

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1400,7 +1400,16 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
         build_env = default_env.Clone()
         build_env.SetOption("implicit_cache", 1)
         for cc in compile_commands:
-            build_flags = cc.get("fragment", "").strip("\" ")
+            build_flags = cc.get("fragment", "").strip()
+            if build_flags.startswith('"') and build_flags.endswith('"'):
+                build_flags = build_flags[1:-1]
+            if build_flags.startswith("@"):
+                resp_path = build_flags[1:].strip('" ')
+                if os.path.isfile(resp_path):
+                    with open(resp_path, "r") as rf:
+                        build_flags = rf.read().replace("\n", " ").strip()
+                else:
+                    continue
             if not build_flags.startswith("-D"):
                 if build_flags.startswith("-include") and ".." in build_flags:
                     source_index = cg.get("sourceIndexes")[0]

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1401,9 +1401,11 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
         build_env.SetOption("implicit_cache", 1)
         for cc in compile_commands:
             build_flags = cc.get("fragment", "").strip()
+            from_response_file = False
             if build_flags.startswith('"') and build_flags.endswith('"'):
                 build_flags = build_flags[1:-1]
             if build_flags.startswith("@"):
+                from_response_file = True
                 # Parse @"path" or @path, possibly followed by extra flags
                 rest = build_flags[1:]
                 if rest.startswith('"'):
@@ -1443,7 +1445,7 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
                     else:
                         # No extra flags, skip this fragment entirely
                         continue
-            if not build_flags.startswith("-D"):
+            if from_response_file or not build_flags.startswith("-D"):
                 if build_flags.startswith("-include") and ".." in build_flags:
                     source_index = cg.get("sourceIndexes")[0]
                     build_flags = _fix_component_relative_include(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for response files in compile fragments using @file or @"file"; paths may be relative to the build directory and any extra flags are merged into build flags.
* **Bug Fixes**
  * Response-file contents are expanded and processed like regular flags; missing response files preserve extra flags when present or skip silently, and macro/include handling is retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->