### PR TITLE
fix: duplicates from response file handling

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1455,9 +1455,6 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
                     with open(resolved_resp_path, "r", encoding="utf-8") as rf:
                         expanded = rf.read().replace("\n", " ").strip()
                     parsed_flags = build_env.ParseFlags(expanded)
-                    # Strip only flags that cause GCC 15 duplication issues (-specs=).
-                    # Architecture-critical flags like -mlongcalls (Xtensa) and
-                    # -march=...xespv (RISC-V/ESP32-P4) MUST be preserved.
                     parsed_flags.pop("CXXFLAGS", None)
                     parsed_flags.pop("LINKFLAGS", None)
                     for key in ("CCFLAGS", "ASFLAGS", "ASPPFLAGS"):
@@ -1469,7 +1466,9 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
                             if not parsed_flags[key]:
                                 del parsed_flags[key]
                     build_env.AppendUnique(**parsed_flags)
-                    # Process any extra flags after the response file ref
+                    # SCons ParseFlags puts -march= into CCFLAGS; the assembler needs it in ASPPFLAGS
+                    if cg.get("language", "") == "ASM":
+                        build_env.AppendUnique(ASPPFLAGS=parsed_flags.get("CCFLAGS", []))
                     if extra:
                         build_flags = extra
                     else:

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1455,6 +1455,25 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
                     with open(resolved_resp_path, "r", encoding="utf-8") as rf:
                         expanded = rf.read().replace("\n", " ").strip()
                     parsed_flags = build_env.ParseFlags(expanded)
+                    # Preserve existing workaround for relative -include paths
+                    source_indexes = cg.get("sourceIndexes") or []
+                    if source_indexes:
+                        source_index = source_indexes[0]
+                        for key in ("CCFLAGS", "ASFLAGS", "ASPPFLAGS"):
+                            flags_list = parsed_flags.get(key, [])
+                            i = 0
+                            while i + 1 < len(flags_list):
+                                if (
+                                    flags_list[i] == "-include"
+                                    and isinstance(flags_list[i + 1], str)
+                                    and ".." in flags_list[i + 1]
+                                ):
+                                    flags_list[i + 1] = _fix_component_relative_include(
+                                        config, flags_list[i + 1], source_index
+                                    )
+                                    i += 2
+                                    continue
+                                i += 1
                     parsed_flags.pop("CXXFLAGS", None)
                     parsed_flags.pop("LINKFLAGS", None)
                     for key in ("CCFLAGS", "ASFLAGS", "ASPPFLAGS"):

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1454,7 +1454,21 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
                 if resolved_resp_path:
                     with open(resolved_resp_path, "r", encoding="utf-8") as rf:
                         expanded = rf.read().replace("\n", " ").strip()
-                    build_flags = (expanded + " " + extra).strip() if extra else expanded
+                    # The @response-file reference is already passed to the
+                    # compiler, so we only extract CPPDEFINES and CPPPATH
+                    # that SCons needs for dependency tracking. Raw compiler
+                    # flags (CCFLAGS) are NOT added to avoid duplication
+                    # which breaks e.g. GCC 15 -specs= processing.
+                    parsed_flags = build_env.ParseFlags(expanded)
+                    for key in ("CCFLAGS", "CXXFLAGS", "LINKFLAGS",
+                                "ASFLAGS", "ASPPFLAGS"):
+                        parsed_flags.pop(key, None)
+                    build_env.AppendUnique(**parsed_flags)
+                    # Process any extra flags after the response file ref
+                    if extra:
+                        build_flags = extra
+                    else:
+                        continue
                 else:
                     # Response file not found - preserve extra flags
                     if extra:

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1454,15 +1454,18 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
                 if resolved_resp_path:
                     with open(resolved_resp_path, "r", encoding="utf-8") as rf:
                         expanded = rf.read().replace("\n", " ").strip()
-                    # The @response-file reference is already passed to the
-                    # compiler, so we only extract CPPDEFINES and CPPPATH
-                    # that SCons needs for dependency tracking. Raw compiler
-                    # flags (CCFLAGS) are NOT added to avoid duplication
-                    # which breaks e.g. GCC 15 -specs= processing.
                     parsed_flags = build_env.ParseFlags(expanded)
-                    for key in ("CCFLAGS", "CXXFLAGS", "LINKFLAGS",
-                                "ASFLAGS", "ASPPFLAGS"):
+                    # Strip only flags that cause GCC 15 duplication issues (-specs=).
+                    # Architecture-critical flags like -mlongcalls MUST be preserved.
+                    for key in ("CXXFLAGS", "LINKFLAGS", "ASFLAGS", "ASPPFLAGS"):
                         parsed_flags.pop(key, None)
+                    if "CCFLAGS" in parsed_flags:
+                        parsed_flags["CCFLAGS"] = [
+                            f for f in parsed_flags["CCFLAGS"]
+                            if not (isinstance(f, str) and f.startswith("-specs="))
+                        ]
+                        if not parsed_flags["CCFLAGS"]:
+                            del parsed_flags["CCFLAGS"]
                     build_env.AppendUnique(**parsed_flags)
                     # Process any extra flags after the response file ref
                     if extra:

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1456,16 +1456,18 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
                         expanded = rf.read().replace("\n", " ").strip()
                     parsed_flags = build_env.ParseFlags(expanded)
                     # Strip only flags that cause GCC 15 duplication issues (-specs=).
-                    # Architecture-critical flags like -mlongcalls MUST be preserved.
-                    for key in ("CXXFLAGS", "LINKFLAGS", "ASFLAGS", "ASPPFLAGS"):
-                        parsed_flags.pop(key, None)
-                    if "CCFLAGS" in parsed_flags:
-                        parsed_flags["CCFLAGS"] = [
-                            f for f in parsed_flags["CCFLAGS"]
-                            if not (isinstance(f, str) and f.startswith("-specs="))
-                        ]
-                        if not parsed_flags["CCFLAGS"]:
-                            del parsed_flags["CCFLAGS"]
+                    # Architecture-critical flags like -mlongcalls (Xtensa) and
+                    # -march=...xespv (RISC-V/ESP32-P4) MUST be preserved.
+                    parsed_flags.pop("CXXFLAGS", None)
+                    parsed_flags.pop("LINKFLAGS", None)
+                    for key in ("CCFLAGS", "ASFLAGS", "ASPPFLAGS"):
+                        if key in parsed_flags:
+                            parsed_flags[key] = [
+                                f for f in parsed_flags[key]
+                                if not (isinstance(f, str) and f.startswith("-specs="))
+                            ]
+                            if not parsed_flags[key]:
+                                del parsed_flags[key]
                     build_env.AppendUnique(**parsed_flags)
                     # Process any extra flags after the response file ref
                     if extra:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Response-file content is now robustly parsed so only intended compiler/linker flags are extracted, reducing duplicates and conflicts.
  * Relative include handling is preserved; unwanted C++/link flags and vendor-specific specs are filtered out and empty entries removed.
  * Assembly builds inherit appropriate C flags; fragments without parsed flags are skipped unless explicit extra flags are provided, honoring user overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->