### PR TITLE
Implement source file generation check and build

### DIFF
--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1523,11 +1523,10 @@ def _ensure_generated_sources(config, project_src_dir, build_dir):
         env=idf_env,
     )
     if result["returncode"] != 0:
-        # Non-fatal: some targets (ULP, cert bundles) are built by other
-        # mechanisms later. SCons will error if a source is truly missing.
-        print("Warning: ninja could not generate some sources")
+        sys.stderr.write("Error: ninja could not generate required sources\n")
         if result.get("err"):
-            print(result["err"])
+            sys.stderr.write(result["err"] + "\n")
+        env.Exit(1)
 
 
 def compile_source_files(

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1492,9 +1492,7 @@ def _ensure_generated_sources(config, project_src_dir, build_dir):
             abs_path = src_path
         # Ninja targets are relative to build_dir, not project_src_dir
         try:
-            ninja_target = str(
-                Path(abs_path).resolve().relative_to(Path(build_dir).resolve())
-            )
+            ninja_target = Path(abs_path).resolve().relative_to(Path(build_dir).resolve()).as_posix()
         except ValueError:
             continue
         if ninja_target not in ninja_custom_targets:
@@ -1516,10 +1514,9 @@ def _ensure_generated_sources(config, project_src_dir, build_dir):
     if result["returncode"] != 0:
         # Non-fatal: some targets (ULP, cert bundles) are built by other
         # mechanisms later. SCons will error if a source is truly missing.
-        if int(ARGUMENTS.get("PIOVERBOSE", 0)):
-            print("Warning: ninja could not generate some sources")
-            if result.get("err"):
-                print(result["err"])
+        print("Warning: ninja could not generate some sources")
+        if result.get("err"):
+            print(result["err"])
 
 
 def compile_source_files(

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1475,7 +1475,11 @@ def _ensure_generated_sources(config, project_src_dir, build_dir):
                 # Extract the output target(s) before the colon
                 outputs = line.split(":")[0].replace("build ", "").strip()
                 for out in outputs.split(" "):
-                    out = out.strip().replace("${cmake_ninja_workdir}", "")
+                    out = fs.to_unix_path(
+                        out.strip()
+                        .replace("${cmake_ninja_workdir}", "")
+                        .replace("$:", ":")
+                    ).lstrip("./")
                     if out:
                         ninja_custom_targets.add(out)
 
@@ -1492,7 +1496,9 @@ def _ensure_generated_sources(config, project_src_dir, build_dir):
             abs_path = src_path
         # Ninja targets are relative to build_dir, not project_src_dir
         try:
-            ninja_target = Path(abs_path).resolve().relative_to(Path(build_dir).resolve()).as_posix()
+            ninja_target = fs.to_unix_path(
+                str(Path(abs_path).resolve().relative_to(Path(build_dir).resolve()))
+            ).lstrip("./")
         except ValueError:
             continue
         if ninja_target not in ninja_custom_targets:
@@ -1508,7 +1514,7 @@ def _ensure_generated_sources(config, project_src_dir, build_dir):
     ninja_exe = os.path.join(NINJA_DIR, "ninja")
     all_targets = [t for t, _ in generated_targets]
     result = exec_command(
-        [ninja_exe, "-C", build_dir] + all_targets,
+        [ninja_exe, "-C", build_dir, *all_targets],
         env=idf_env,
     )
     if result["returncode"] != 0:
@@ -2142,8 +2148,6 @@ def install_python_deps():
         return
 
     deps = {
-        # https://github.com/platformio/platformio-core/issues/4614
-        "urllib3": "<2",
         # https://github.com/platformio/platform-espressif32/issues/635
         "cryptography": "~=44.0.0",
         "pyparsing": ">=3.1.0,<4",

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1461,9 +1461,55 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
     return build_envs
 
 
+def _ensure_generated_sources(config, project_src_dir):
+    """Run ninja to build any generated source files that don't exist yet."""
+    generated_targets = []
+    for source in config.get("sources", []):
+        if not source.get("isGenerated"):
+            continue
+        src_path = source["path"]
+        if src_path.endswith(".rule"):
+            continue
+        if not os.path.isabs(src_path):
+            abs_path = str(Path(project_src_dir) / src_path)
+        else:
+            abs_path = src_path
+        if not os.path.isfile(abs_path):
+            # Ninja targets are relative to BUILD_DIR, not PROJECT_DIR
+            try:
+                ninja_target = str(
+                    Path(abs_path).resolve().relative_to(Path(BUILD_DIR).resolve())
+                )
+            except ValueError:
+                ninja_target = src_path
+            generated_targets.append((ninja_target, src_path))
+
+    if not generated_targets:
+        return
+
+    idf_env = os.environ.copy()
+    populate_idf_env_vars(idf_env)
+    NINJA_DIR = platform.get_package_dir("tool-ninja")
+    ninja_exe = os.path.join(NINJA_DIR, "ninja")
+    for ninja_target, src_path in generated_targets:
+        print("Generating source: %s" % src_path)
+        result = exec_command(
+            [ninja_exe, "-C", BUILD_DIR, ninja_target],
+            env=idf_env,
+        )
+        if result["returncode"] != 0:
+            sys.stderr.write(
+                "Error: Failed to generate source file '%s'\n" % target
+            )
+            if result.get("err"):
+                sys.stderr.write(result["err"] + "\n")
+            env.Exit(1)
+
+
 def compile_source_files(
     config, default_env, project_src_dir, prepend_dir=None, debug_allowed=True
 ):
+    _ensure_generated_sources(config, project_src_dir)
     build_envs = prepare_build_envs(config, default_env, debug_allowed)
     objects = []
     # Canonical, symlink-resolved absolute path of the components directory
@@ -1483,19 +1529,25 @@ def compile_source_files(
 
             obj_path = str(Path("$BUILD_DIR") / (prepend_dir or ""))
             src_path_obj = Path(src_path).resolve()
+            build_dir_path = Path(BUILD_DIR).resolve()
             try:
                 rel = src_path_obj.relative_to(components_dir_path)
                 obj_path = str(Path(obj_path) / str(rel))
             except ValueError:
-                # Preserve project substructure when possible
+                # Generated sources in the build directory
                 try:
-                    rel_prj = src_path_obj.relative_to(Path(project_src_dir).resolve())
-                    obj_path = str(Path(obj_path) / str(rel_prj))
+                    rel_build = src_path_obj.relative_to(build_dir_path)
+                    obj_path = str(Path(obj_path) / str(rel_build))
                 except ValueError:
-                    if not os.path.isabs(source["path"]):
-                        obj_path = str(Path(obj_path) / source["path"])
-                    else:
-                        obj_path = str(Path(obj_path) / os.path.basename(src_path))
+                    # Preserve project substructure when possible
+                    try:
+                        rel_prj = src_path_obj.relative_to(Path(project_src_dir).resolve())
+                        obj_path = str(Path(obj_path) / str(rel_prj))
+                    except ValueError:
+                        if not os.path.isabs(source["path"]):
+                            obj_path = str(Path(obj_path) / source["path"])
+                        else:
+                            obj_path = str(Path(obj_path) / os.path.basename(src_path))
 
             preserve_source_file_extension = board.get(
                 "build.esp-idf.preserve_source_file_extension", "yes"

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1514,7 +1514,7 @@ def _ensure_generated_sources(config, project_src_dir, build_dir):
     ninja_exe = os.path.join(NINJA_DIR, "ninja")
     all_targets = [t for t, _ in generated_targets]
     result = exec_command(
-        [ninja_exe, "-C", build_dir, *all_targets],
+        [ninja_exe, "-C", build_dir, "-k", "0", *all_targets],
         env=idf_env,
     )
     if result["returncode"] != 0:

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1508,19 +1508,18 @@ def _ensure_generated_sources(config, project_src_dir, build_dir):
     populate_idf_env_vars(idf_env)
     NINJA_DIR = platform.get_package_dir("tool-ninja")
     ninja_exe = os.path.join(NINJA_DIR, "ninja")
-    for ninja_target, src_path in generated_targets:
-        print("Generating source: %s" % src_path)
-        result = exec_command(
-            [ninja_exe, "-C", build_dir, ninja_target],
-            env=idf_env,
-        )
-        if result["returncode"] != 0:
-            sys.stderr.write(
-                "Error: Failed to generate source file '%s'\n" % src_path
-            )
+    all_targets = [t for t, _ in generated_targets]
+    result = exec_command(
+        [ninja_exe, "-C", build_dir] + all_targets,
+        env=idf_env,
+    )
+    if result["returncode"] != 0:
+        # Non-fatal: some targets (ULP, cert bundles) are built by other
+        # mechanisms later. SCons will error if a source is truly missing.
+        if int(ARGUMENTS.get("PIOVERBOSE", 0)):
+            print("Warning: ninja could not generate some sources")
             if result.get("err"):
-                sys.stderr.write(result["err"] + "\n")
-            env.Exit(1)
+                print(result["err"])
 
 
 def compile_source_files(

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1461,8 +1461,24 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
     return build_envs
 
 
-def _ensure_generated_sources(config, project_src_dir):
+def _ensure_generated_sources(config, project_src_dir, build_dir):
     """Run ninja to build any generated source files that don't exist yet."""
+    ninja_buildfile = str(Path(build_dir) / "build.ninja")
+    if not os.path.isfile(ninja_buildfile):
+        return
+
+    # Read ninja build file once to find which generated targets have CUSTOM_COMMANDs
+    ninja_custom_targets = set()
+    with open(ninja_buildfile, encoding="utf8") as fp:
+        for line in fp:
+            if "CUSTOM_COMMAND" in line and line.startswith("build "):
+                # Extract the output target(s) before the colon
+                outputs = line.split(":")[0].replace("build ", "").strip()
+                for out in outputs.split(" "):
+                    out = out.strip().replace("${cmake_ninja_workdir}", "")
+                    if out:
+                        ninja_custom_targets.add(out)
+
     generated_targets = []
     for source in config.get("sources", []):
         if not source.get("isGenerated"):
@@ -1475,13 +1491,15 @@ def _ensure_generated_sources(config, project_src_dir):
         else:
             abs_path = src_path
         if not os.path.isfile(abs_path):
-            # Ninja targets are relative to BUILD_DIR, not PROJECT_DIR
+            # Ninja targets are relative to build_dir, not project_src_dir
             try:
                 ninja_target = str(
-                    Path(abs_path).resolve().relative_to(Path(BUILD_DIR).resolve())
+                    Path(abs_path).resolve().relative_to(Path(build_dir).resolve())
                 )
             except ValueError:
-                ninja_target = src_path
+                continue
+            if ninja_target not in ninja_custom_targets:
+                continue
             generated_targets.append((ninja_target, src_path))
 
     if not generated_targets:
@@ -1494,12 +1512,12 @@ def _ensure_generated_sources(config, project_src_dir):
     for ninja_target, src_path in generated_targets:
         print("Generating source: %s" % src_path)
         result = exec_command(
-            [ninja_exe, "-C", BUILD_DIR, ninja_target],
+            [ninja_exe, "-C", build_dir, ninja_target],
             env=idf_env,
         )
         if result["returncode"] != 0:
             sys.stderr.write(
-                "Error: Failed to generate source file '%s'\n" % target
+                "Error: Failed to generate source file '%s'\n" % src_path
             )
             if result.get("err"):
                 sys.stderr.write(result["err"] + "\n")
@@ -1509,7 +1527,7 @@ def _ensure_generated_sources(config, project_src_dir):
 def compile_source_files(
     config, default_env, project_src_dir, prepend_dir=None, debug_allowed=True
 ):
-    _ensure_generated_sources(config, project_src_dir)
+    _ensure_generated_sources(config, project_src_dir, BUILD_DIR)
     build_envs = prepare_build_envs(config, default_env, debug_allowed)
     objects = []
     # Canonical, symlink-resolved absolute path of the components directory

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1531,7 +1531,10 @@ def _ensure_generated_sources(config, project_src_dir, build_dir):
 def compile_source_files(
     config, default_env, project_src_dir, prepend_dir=None, debug_allowed=True
 ):
-    _ensure_generated_sources(config, project_src_dir, BUILD_DIR)
+    active_build_dir = (
+        str(Path(BUILD_DIR) / prepend_dir) if prepend_dir else BUILD_DIR
+    )
+    _ensure_generated_sources(config, project_src_dir, active_build_dir)
     build_envs = prepare_build_envs(config, default_env, debug_allowed)
     objects = []
     # Canonical, symlink-resolved absolute path of the components directory
@@ -1551,7 +1554,7 @@ def compile_source_files(
 
             obj_path = str(Path("$BUILD_DIR") / (prepend_dir or ""))
             src_path_obj = Path(src_path).resolve()
-            build_dir_path = Path(BUILD_DIR).resolve()
+            build_dir_path = Path(active_build_dir).resolve()
             try:
                 rel = src_path_obj.relative_to(components_dir_path)
                 obj_path = str(Path(obj_path) / str(rel))

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1480,8 +1480,10 @@ def _ensure_generated_sources(config, project_src_dir, build_dir):
         for line in fp:
             if "CUSTOM_COMMAND" in line and line.startswith("build "):
                 # Extract the output target(s) before the colon
-                outputs = line.split(":")[0].replace("build ", "").strip()
-                for out in outputs.split(" "):
+                outputs = re.split(
+                    r":\s+CUSTOM_COMMAND\b", line, maxsplit=1
+                )[0].replace("build ", "").strip()
+                for out in outputs.split():
                     out = fs.to_unix_path(
                         out.strip()
                         .replace("${cmake_ninja_workdir}", "")

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1490,17 +1490,16 @@ def _ensure_generated_sources(config, project_src_dir, build_dir):
             abs_path = str(Path(project_src_dir) / src_path)
         else:
             abs_path = src_path
-        if not os.path.isfile(abs_path):
-            # Ninja targets are relative to build_dir, not project_src_dir
-            try:
-                ninja_target = str(
-                    Path(abs_path).resolve().relative_to(Path(build_dir).resolve())
-                )
-            except ValueError:
-                continue
-            if ninja_target not in ninja_custom_targets:
-                continue
-            generated_targets.append((ninja_target, src_path))
+        # Ninja targets are relative to build_dir, not project_src_dir
+        try:
+            ninja_target = str(
+                Path(abs_path).resolve().relative_to(Path(build_dir).resolve())
+            )
+        except ValueError:
+            continue
+        if ninja_target not in ninja_custom_targets:
+            continue
+        generated_targets.append((ninja_target, src_path))
 
     if not generated_targets:
         return

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1463,6 +1463,13 @@ def prepare_build_envs(config, default_env, debug_allowed=True):
 
 def _ensure_generated_sources(config, project_src_dir, build_dir):
     """Run ninja to build any generated source files that don't exist yet."""
+    generated_sources = [
+        s for s in config.get("sources", [])
+        if s.get("isGenerated") and not s["path"].endswith(".rule")
+    ]
+    if not generated_sources:
+        return
+
     ninja_buildfile = str(Path(build_dir) / "build.ninja")
     if not os.path.isfile(ninja_buildfile):
         return
@@ -1484,12 +1491,8 @@ def _ensure_generated_sources(config, project_src_dir, build_dir):
                         ninja_custom_targets.add(out)
 
     generated_targets = []
-    for source in config.get("sources", []):
-        if not source.get("isGenerated"):
-            continue
+    for source in generated_sources:
         src_path = source["path"]
-        if src_path.endswith(".rule"):
-            continue
         if not os.path.isabs(src_path):
             abs_path = str(Path(project_src_dir) / src_path)
         else:

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -286,6 +286,14 @@ def install_python_deps(python_exe, external_uv_executable, uv_cache_dir=None):
 
         if not uv_in_penv_available:
             # Fallback to pip to install uv into penv
+            # uv-created venvs don't include pip, so ensure it's available first
+            try:
+                subprocess.run(
+                    [python_exe, "-m", "ensurepip", "--default-pip"],
+                    capture_output=True, timeout=60
+                )
+            except Exception:
+                pass
             try:
                 subprocess.check_call(
                     [python_exe, "-m", "pip", "install", "uv>=0.1.0", "--quiet", "--no-cache-dir"],

--- a/builder/penv_setup.py
+++ b/builder/penv_setup.py
@@ -57,7 +57,6 @@ python_deps = {
     "zopfli": ">=0.2.2",
     "intelhex": ">=2.3.0",
     "rich": ">=14.0.0",
-    "urllib3": "<2",
     "cryptography": ">=45.0.3",
     "certifi": ">=2025.8.3",
     "ecdsa": ">=0.19.1",


### PR DESCRIPTION
@coderabbitai analyze if this fixes the issues with idf components and HybridCompile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Pre-generate framework-produced source files before compilation.
  * Object output path logic now preserves build-tree source structure when applicable.

* **Bug Fixes**
  * Generation commands executed during build now report errors and halt compilation on failure.
  * Virtual environment setup attempts to bootstrap pip before installing packages.

* **Chores**
  * Relaxed urllib3 version constraint to allow newer releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->