### PR TITLE
hash deps for penv reinstall

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2189,6 +2189,15 @@ def install_python_deps():
             )
         )
 
+    if IS_WINDOWS and "windows-curses" not in installed_packages:
+        # Install windows-curses in the IDF Python environment
+        env.Execute(
+            env.VerboseAction(
+                f'"{UV_EXE}" pip install --python "{python_exe_path}" windows-curses',
+                "Installing windows-curses package with uv",
+            )
+        )
+
 
 def get_idf_venv_dir():
     # The name of the IDF venv contains the IDF version to avoid possible conflicts and

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2189,15 +2189,6 @@ def install_python_deps():
             )
         )
 
-    if IS_WINDOWS and "windows-curses" not in installed_packages:
-        # Install windows-curses in the IDF Python environment
-        env.Execute(
-            env.VerboseAction(
-                f'"{UV_EXE}" pip install --python "{python_exe_path}" windows-curses',
-                "Installing windows-curses package with uv",
-            )
-        )
-
 
 def get_idf_venv_dir():
     # The name of the IDF venv contains the IDF version to avoid possible conflicts and
@@ -2235,7 +2226,7 @@ def ensure_python_venv_available():
                 venv_data = json.load(fp)
                 if venv_data.get("version", "") != IDF_ENV_VERSION:
                     print(
-                        "Warning! IDF virtual environment version changed!"
+                        "IDF virtual environment version changed!"
                     )
                     return True
                 if (

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2131,6 +2131,17 @@ def _get_uv_exe():
     return get_executable_path(str(Path(PLATFORMIO_DIR) / "penv"), "uv")
 
 
+def _get_python_deps():
+    """Get the required Python dependencies for ESP-IDF"""
+    return {
+        # https://github.com/platformio/platform-espressif32/issues/635
+        "cryptography": "~=44.0.0",
+        "pyparsing": ">=3.1.0,<4",
+        "idf-component-manager": "~=2.4.8",
+        "esp-idf-kconfig": "~=2.5.0"
+    }
+
+
 def install_python_deps():
     UV_EXE = _get_uv_exe()
 
@@ -2154,13 +2165,7 @@ def install_python_deps():
     if os.path.isfile(skip_python_packages):
         return
 
-    deps = {
-        # https://github.com/platformio/platform-espressif32/issues/635
-        "cryptography": "~=44.0.0",
-        "pyparsing": ">=3.1.0,<4",
-        "idf-component-manager": "~=2.4.8",
-        "esp-idf-kconfig": "~=3.7.0"
-    }
+    deps = _get_python_deps()
 
     python_exe_path = get_python_exe()
     installed_packages = _get_installed_uv_packages(python_exe_path)
@@ -2219,7 +2224,12 @@ def ensure_python_venv_available():
             print("Failed to extract Python version from IDF virtual env!")
             return None
 
-    def _is_venv_outdated(venv_data_file):
+    def _get_deps_hash(deps_dict):
+        import hashlib
+        deps_str = json.dumps(deps_dict, sort_keys=True)
+        return hashlib.sha256(deps_str.encode()).hexdigest()
+
+    def _is_venv_outdated(venv_data_file, current_deps):
         try:
             with open(venv_data_file, "r", encoding="utf8") as fp:
                 venv_data = json.load(fp)
@@ -2235,6 +2245,11 @@ def ensure_python_venv_available():
                     print(
                         "Warning! Python version in the IDF virtual environment"
                         " differs from the current Python!"
+                    )
+                    return True
+                if venv_data.get("deps_hash", "") != _get_deps_hash(current_deps):
+                    print(
+                        "Warning! Python dependencies have changed!"
                     )
                     return True
                 return False
@@ -2269,15 +2284,19 @@ def ensure_python_venv_available():
             sys.stderr.write("Error: Failed to create a proper virtual environment. Missing the Python executable!\n")
             env.Exit(1)
 
+    # Define deps here so we can track changes
+    deps = _get_python_deps()
+
     venv_dir = get_idf_venv_dir()
     venv_data_file = str(Path(venv_dir) / "pio-idf-venv.json")
-    if not os.path.isfile(venv_data_file) or _is_venv_outdated(venv_data_file):
+    if not os.path.isfile(venv_data_file) or _is_venv_outdated(venv_data_file, deps):
         _create_venv(venv_dir)
         install_python_deps()
         with open(venv_data_file, "w", encoding="utf8") as fp:
             venv_info = {
                 "version": IDF_ENV_VERSION,
-                "python_version": _get_idf_venv_python_version()
+                "python_version": _get_idf_venv_python_version(),
+                "deps_hash": _get_deps_hash(deps)
             }
             json.dump(venv_info, fp, indent=2)
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2133,13 +2133,18 @@ def _get_uv_exe():
 
 def _get_python_deps():
     """Get the required Python dependencies for ESP-IDF"""
-    return {
+    deps = {
         # https://github.com/platformio/platform-espressif32/issues/635
         "cryptography": "~=44.0.0",
         "pyparsing": ">=3.1.0,<4",
         "idf-component-manager": "~=2.4.8",
         "esp-idf-kconfig": "~=3.7.0"
     }
+
+    if IS_WINDOWS:
+        deps["windows-curses"] = ">=2.4.2a2"
+
+    return deps
 
 
 def install_python_deps(deps=None):
@@ -2183,18 +2188,9 @@ def install_python_deps(deps=None):
         # Use uv to install packages in the specific Python environment
         env.Execute(
             env.VerboseAction(
-                f'"{UV_EXE}" pip install --python "{python_exe_path}" --prerelease=allow {packages_str}',
+                f'"{UV_EXE}" pip install --python "{python_exe_path}" {packages_str}',
                 "Installing ESP-IDF's Python dependencies with uv",
             )
-        )
-
-    if IS_WINDOWS and "windows-curses" not in installed_packages:
-        # Install windows-curses in the IDF Python environment (required for ASCII based menuconfig)
-        env.Execute(
-                env.VerboseAction(
-                    f'"{UV_EXE}" pip install --python "{python_exe_path}" windows-curses>=2.4.2a2 --prerelease=allow',
-                    "Installing windows-curses package with uv",
-                )
         )
 
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2138,7 +2138,7 @@ def _get_python_deps():
         "cryptography": "~=44.0.0",
         "pyparsing": ">=3.1.0,<4",
         "idf-component-manager": "~=2.4.8",
-        "esp-idf-kconfig": "~=2.5.0"
+        "esp-idf-kconfig": "~=3.7.0"
     }
 
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2226,7 +2226,7 @@ def ensure_python_venv_available():
                 venv_data = json.load(fp)
                 if venv_data.get("version", "") != IDF_ENV_VERSION:
                     print(
-                        "IDF virtual environment version changed!"
+                        "Warning! IDF virtual environment version changed!"
                     )
                     return True
                 if (

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2142,8 +2142,9 @@ def _get_python_deps():
     }
 
 
-def install_python_deps():
+def install_python_deps(deps=None):
     UV_EXE = _get_uv_exe()
+    deps = deps or _get_python_deps()
 
     def _get_installed_uv_packages(python_exe_path):
         result = {}
@@ -2164,8 +2165,6 @@ def install_python_deps():
     skip_python_packages = str(Path(FRAMEWORK_DIR) / ".pio_skip_pypackages")
     if os.path.isfile(skip_python_packages):
         return
-
-    deps = _get_python_deps()
 
     python_exe_path = get_python_exe()
     installed_packages = _get_installed_uv_packages(python_exe_path)
@@ -2291,7 +2290,7 @@ def ensure_python_venv_available():
     venv_data_file = str(Path(venv_dir) / "pio-idf-venv.json")
     if not os.path.isfile(venv_data_file) or _is_venv_outdated(venv_data_file, deps):
         _create_venv(venv_dir)
-        install_python_deps()
+        install_python_deps(deps)
         with open(venv_data_file, "w", encoding="utf8") as fp:
             venv_info = {
                 "version": IDF_ENV_VERSION,

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2183,7 +2183,7 @@ def install_python_deps(deps=None):
         # Use uv to install packages in the specific Python environment
         env.Execute(
             env.VerboseAction(
-                f'"{UV_EXE}" pip install --python "{python_exe_path}" {packages_str}',
+                f'"{UV_EXE}" pip install --python "{python_exe_path}" --prerelease=allow {packages_str}',
                 "Installing ESP-IDF's Python dependencies with uv",
             )
         )

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2189,12 +2189,12 @@ def install_python_deps(deps=None):
         )
 
     if IS_WINDOWS and "windows-curses" not in installed_packages:
-        # Install windows-curses in the IDF Python environment
+        # Install windows-curses in the IDF Python environment (required for ASCII based menuconfig)
         env.Execute(
-            env.VerboseAction(
-                f'"{UV_EXE}" pip install --python "{python_exe_path}" windows-curses>=2.4.2a2',
-                "Installing windows-curses package with uv",
-            )
+                env.VerboseAction(
+                    f'"{UV_EXE}" pip install --python "{python_exe_path}" windows-curses>=2.4.2a2 --prerelease=allow',
+                    "Installing windows-curses package with uv",
+                )
         )
 
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2192,7 +2192,7 @@ def install_python_deps(deps=None):
         # Install windows-curses in the IDF Python environment
         env.Execute(
             env.VerboseAction(
-                f'"{UV_EXE}" pip install --python "{python_exe_path}" windows-curses',
+                f'"{UV_EXE}" pip install --python "{python_exe_path}" windows-curses>=2.4.2a2',
                 "Installing windows-curses package with uv",
             )
         )

--- a/platform.py
+++ b/platform.py
@@ -17,12 +17,12 @@ import sys
 from platformio.compat import IS_WINDOWS
 
 pyver = sys.version_info
-    allowed = (3, 10) <= pyver < (3, 15)
-    supported = "3.10, 3.11, 3.12, 3.13, 3.14"
+allowed = (3, 10) <= pyver < (3, 15)
+supported = "3.10, 3.11, 3.12, 3.13, 3.14"
+
 if not allowed:
     print(f"ERROR: Python version must be {supported}.", file=sys.stderr)
     print(f"Current Python version: {pyver.major}.{pyver.minor}.{pyver.micro}", file=sys.stderr)
-    print(f"Supported versions: {supported}", file=sys.stderr)
     raise SystemExit(1)
 
 # LZMA support check

--- a/platform.py
+++ b/platform.py
@@ -17,10 +17,6 @@ import sys
 from platformio.compat import IS_WINDOWS
 
 pyver = sys.version_info
-if IS_WINDOWS:
-    allowed = (3, 10) <= pyver < (3, 14)
-    supported = "3.10, 3.11, 3.12, 3.13"
-else:
     allowed = (3, 10) <= pyver < (3, 15)
     supported = "3.10, 3.11, 3.12, 3.13, 3.14"
 if not allowed:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Python virtual environment management with deterministic dependency hashing and updated venv metadata so environments refresh when dependency specs change.

* **Bug Fixes**
  * Windows installer now uses a compatible curses package version to prevent mismatched installs.
  * Dependency installation updated to allow prerelease releases when resolving packages.

* **Chores**
  * CI workflow and runtime compatibility updated to target Python 3.14 uniformly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->