### PR TITLE
Fix mbedtls certificate bundle generation to match esp-idf v6.1.0

### DIFF
--- a/builder/build_lib/idf_component.yml
+++ b/builder/build_lib/idf_component.yml
@@ -6,7 +6,7 @@ dependencies:
     rules:
       - if: "target == esp32c2"
   espressif/fb_gfx:
-    version: "master"
+    version: "v61"
     path: components/fb_gfx
     git: https://github.com/Jason2866/esp32-arduino-lib-builder.git
     require: public

--- a/builder/build_lib/idf_component.yml
+++ b/builder/build_lib/idf_component.yml
@@ -8,7 +8,7 @@ dependencies:
   espressif/fb_gfx:
     version: "master"
     path: components/fb_gfx
-    git: https://github.com/espressif/esp32-arduino-lib-builder.git
+    git: https://github.com/Jason2866/esp32-arduino-lib-builder.git
     require: public
     rules:
-      - if: "target in [esp32, esp32s2, esp32s3, esp32p4]"
+      - if: "target in [esp32, esp32s2, esp32s3, esp32p4, esp32s31]"

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2360,7 +2360,7 @@ def _get_python_deps():
         # https://github.com/platformio/platform-espressif32/issues/635
         "cryptography": "~=44.0.0",
         "pyparsing": ">=3.1.0,<4",
-        "idf-component-manager": "~=2.5.0",
+        "idf-component-manager": "~=3.1.0",
         "esp-idf-kconfig": "~=3.7.0"
     }
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2257,29 +2257,38 @@ def preprocess_linker_file(src_ld_script, target_ld_script, config_dir=None, ext
     
     # IDF 6.0+ uses linker_script_preprocessor.cmake with CFLAGS approach
     if framework_version_list[0] >= 6:
-        include_dirs = [f'"{config_dir}"']
-        include_dirs.append(f'"{fs.to_unix_path(str(Path(FRAMEWORK_DIR) / "components" / "esp_system" / "ld"))}"')
-        
+        all_include_dirs = [config_dir]
+        all_include_dirs.append(
+            fs.to_unix_path(str(Path(FRAMEWORK_DIR) / "components" / "esp_system" / "ld"))
+        )
         if extra_include_dirs:
-            include_dirs.extend(f'"{fs.to_unix_path(dir_path)}"' for dir_path in extra_include_dirs)
-        
-        cflags_value = "-I" + " -I".join(include_dirs)
-        
+            all_include_dirs.extend(
+                fs.to_unix_path(d) for d in extra_include_dirs
+            )
+
+        # Each include path is individually escaped so CMake receives:
+        #   -DCFLAGS=-I\"path1\" -I\"path2\"
+        # matching the upstream reference implementation.
+        cflags_value = " ".join(
+            '-I\\"%s\\"' % d for d in all_include_dirs
+        )
+
+        cmd = " ".join([
+            '"%s"' % CMAKE_DIR,
+            '-DCC="$CC"',
+            '-DSOURCE="%s"' % src_ld_script,
+            '-DTARGET="%s"' % target_ld_script,
+            '"-DCFLAGS=%s"' % cflags_value,
+            "-P",
+            '"%s"' % fs.to_unix_path(
+                str(Path(FRAMEWORK_DIR) / "tools" / "cmake" / "linker_script_preprocessor.cmake")
+            ),
+        ])
+
         return env.Command(
             target_ld_script,
             src_ld_script,
-            env.VerboseAction(
-                " ".join([
-                    f'"{CMAKE_DIR}"',
-                    '-DCC="$CC"',
-                    f'-DSOURCE="{src_ld_script}"',
-                    f'-DTARGET="{target_ld_script}"',
-                    f'-DCFLAGS="{cflags_value}"',
-                    "-P",
-                    f'"{fs.to_unix_path(str(Path(FRAMEWORK_DIR) / "tools" / "cmake" / "linker_script_preprocessor.cmake"))}"',
-                ]),
-                "Generating LD script $TARGET",
-            ),
+            env.VerboseAction(cmd, "Generating LD script $TARGET"),
         )
     else:
         # IDF 5.x: Use legacy linker_script_generator.cmake method

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2784,12 +2784,15 @@ env.Depends("$BUILD_DIR/$PROGNAME$PROGSUFFIX", partition_table)
 # In IDF 6.x, tf-psa-crypto depends on mbedtls symbols but may appear before
 # them in the CMake commandFragments. Wrapping them in --start-group/--end-group
 # tells the linker to rescan archives until all symbols are resolved.
-precompiled_libs = link_args.get("LIBS", [])
+# Only .a basenames are wrapped — plain -l flags (e.g. -lc, -lm) are left as-is.
+all_libs = link_args.get("LIBS", [])
 precompiled_libpaths = link_args.get("LIBPATH", [])
-if precompiled_libs:
-    # Resolve basename -> full path so we can pass absolute paths directly
+archive_libs = [lib for lib in all_libs if lib.endswith(".a")]
+plain_libs = [lib for lib in all_libs if not lib.endswith(".a")]
+if archive_libs:
+    # Resolve basename -> full path so the linker finds each archive directly
     libpath_libs_flags = []
-    for lib in precompiled_libs:
+    for lib in archive_libs:
         full_path = None
         for lp in precompiled_libpaths:
             candidate = os.path.join(lp, lib)
@@ -2803,7 +2806,8 @@ if precompiled_libs:
     link_args["LINKFLAGS"] = link_args.get("LINKFLAGS", []) + (
         ["-Wl,--start-group"] + libpath_libs_flags + ["-Wl,--end-group"]
     )
-    link_args["LIBS"] = []
+    # Keep plain -l flags in LIBS; only remove the .a entries we've handled
+    link_args["LIBS"] = plain_libs
     # Note: keep LIBPATH intact — it contains -L dirs needed by -T linker scripts
     # (e.g. esp32.peripherals.ld from the ROM ld directory)
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2779,10 +2779,9 @@ env.Depends("$BUILD_DIR/$PROGNAME$PROGSUFFIX", partition_table)
 # Main environment configuration
 #
 
-# In IDF 6.x, the mbedtls component family has circular cross-library dependencies
-# (libtfpsacrypto.a needs symbols from libmbed-builtin.a and vice versa).
-# SCons places LIBS after LINKFLAGS in the link command. The --start-group/--end-group
-# flags from CMake's extra_flags sit in LINKFLAGS and do NOT wrap the LIBS list.
+# In IDF 6.x, the mbedtls component family has circular cross-library dependencies.
+# SCons places LIBS after LINKFLAGS in the link command, so --start-group/--end-group
+# flags in extra_flags (LINKFLAGS) do NOT wrap the LIBS list.
 # Fix: patch LINKCOM to wrap $_LIBFLAGS with group markers so all libs are rescanned.
 _linkcom = env.get("LINKCOM", "")
 if "$_LIBFLAGS" in str(_linkcom) and "-Wl,--start-group" not in str(_linkcom):
@@ -2793,37 +2792,11 @@ if "$_LIBFLAGS" in str(_linkcom) and "-Wl,--start-group" not in str(_linkcom):
         )
     )
 
-# Strip --start-group/--end-group from extra_flags since LINKCOM now handles grouping
+# Strip --start-group/--end-group from extra_flags to avoid double-wrapping
 extra_flags = [
     f for f in extra_flags
     if f not in ("-Wl,--start-group", "-Wl,--end-group")
 ]
-
-# Handle precompiled absolute-path archives from extract_link_args/_add_archive.
-# These are .a basenames in link_args["LIBS"] with their dirs in LIBPATH.
-# They are already inside the LINKCOM group via $_LIBFLAGS after MergeFlags.
-all_libs = link_args.get("LIBS", [])
-precompiled_libpaths = link_args.get("LIBPATH", [])
-archive_libs = [lib for lib in all_libs if lib.endswith(".a")]
-plain_libs = [lib for lib in all_libs if not lib.endswith(".a")]
-
-if archive_libs:
-    # Resolve to full paths. Add to LIBS (not LINKFLAGS) so they land inside
-    # the --start-group/$_LIBFLAGS/--end-group wrapper in LINKCOM.
-    resolved_archives = []
-    for lib in archive_libs:
-        full_path = None
-        for lp in precompiled_libpaths:
-            candidate = os.path.join(lp, lib)
-            if os.path.isfile(candidate):
-                full_path = candidate
-                break
-        resolved_archives.append(full_path if full_path else lib)
-    # Replace bare basenames with resolved paths and add back as plain entries
-    # SCons treats strings in LIBS as -l<name> unless the name contains a path sep
-    # or ends in .a — full paths are passed as-is to the linker.
-    link_args["LIBS"] = plain_libs + resolved_archives
-    # Keep LIBPATH for -L dirs needed by -T linker scripts
 
 project_flags.update(link_args)
 env.MergeFlags(link_args)

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1921,11 +1921,75 @@ def find_lib_deps(components_map, elf_config, link_args, ignore_components=None)
     return result
 
 
+def _patch_bootloader_ninja_ld_cflags(bootloader_build_dir, idf_variant):
+    """Patch the bootloader's build.ninja to add the missing include directory for
+    bootloader linker script preprocessing.
+
+    IDF v6.0's utilities.cmake preprocess_linker_file() adds the *parent* of the
+    chip-specific ld directory (e.g. .../main/ld) to CFLAGS, but not the directory
+    itself (.../main/ld/<idf_variant>/).  This means the C preprocessor cannot
+    resolve #include "bootloader.sections.common.ld" inside bootloader.sections.ld.in
+    because that file lives in the chip-specific subdirectory.
+
+    We fix this by scanning build.ninja for every CUSTOM_COMMAND line that references
+    linker_script_preprocessor.cmake and patching its -DCFLAGS= value to also include
+    the chip-specific ld directory.
+    """
+    ninja_file = str(Path(bootloader_build_dir) / "build.ninja")
+    if not os.path.isfile(ninja_file):
+        return
+
+    # The directory that is missing from the include path:
+    # .../components/bootloader/subproject/main/ld/<idf_variant>
+    missing_inc = fs.to_unix_path(str(
+        Path(FRAMEWORK_DIR) / "components" / "bootloader" / "subproject"
+        / "main" / "ld" / idf_variant
+    ))
+
+    with open(ninja_file, encoding="utf-8") as fh:
+        content = fh.read()
+
+    if "linker_script_preprocessor.cmake" not in content:
+        return  # nothing to patch
+
+    if missing_inc in content:
+        return  # already present (incremental build)
+
+    patched_lines = []
+    changed = False
+    for line in content.splitlines(keepends=True):
+        # Only touch build lines that invoke linker_script_preprocessor.cmake
+        if "linker_script_preprocessor.cmake" in line and "-DCFLAGS=" in line:
+            # Insert -I"<missing_inc>" just before the closing quote of -DCFLAGS=
+            # The flag looks like:  -DCFLAGS=-C -I"dir1" ...  (may or may not be quoted)
+            # We append our extra -I at the end of the CFLAGS value, before any
+            # following space-separated cmake argument.
+            #
+            # Strategy: find the -DCFLAGS= token and append our flag after the last
+            # existing -I"..." or right after the = sign if no -I flags exist yet.
+            replacement = ' -I\\"%s\\"' % missing_inc
+            # Insert before the first cmake argument that follows -DCFLAGS=...
+            # i.e. before " -P " which introduces the script path.
+            if " -P " in line:
+                line = line.replace(" -P ", replacement + " -P ", 1)
+                changed = True
+        patched_lines.append(line)
+
+    if changed:
+        with open(ninja_file, "w", encoding="utf-8") as fh:
+            fh.writelines(patched_lines)
+        print(
+            "Patched bootloader build.ninja: added -I\"%s\" to linker script CFLAGS"
+            % missing_inc
+        )
+
+
 def build_bootloader(sdk_config):
     bootloader_src_dir = str(Path(FRAMEWORK_DIR) / "components" / "bootloader" / "subproject")
+    bootloader_build_dir = str(Path(BUILD_DIR) / "bootloader")
     code_model = get_cmake_code_model(
         bootloader_src_dir,
-        str(Path(BUILD_DIR) / "bootloader"),
+        bootloader_build_dir,
         [
             "-DIDF_TARGET=" + idf_variant,
             "-DPYTHON_DEPS_CHECKED=1",
@@ -1940,6 +2004,10 @@ def build_bootloader(sdk_config):
             f"-DESP_IDF_VERSION_MINOR={framework_version.split('.')[1]}",
         ],
     )
+
+    # Fix IDF v6.0 bug: the chip-specific ld dir is missing from CFLAGS in the
+    # ninja CUSTOM_COMMANDs that preprocess bootloader linker scripts.
+    _patch_bootloader_ninja_ld_cflags(bootloader_build_dir, idf_variant)
 
     if not code_model:
         sys.stderr.write("Error: Couldn't find code model for bootloader\n")

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2779,19 +2779,38 @@ env.Depends("$BUILD_DIR/$PROGNAME$PROGSUFFIX", partition_table)
 # Main environment configuration
 #
 
-# Precompiled absolute-path archives (e.g. libtfpsacrypto.a, libmbedcrypto.a)
-# are appended to LIBS via extract_link_args/_add_archive in CMake order.
-# In IDF 6.x, tf-psa-crypto depends on mbedtls symbols but may appear before
-# them in the CMake commandFragments. Wrapping them in --start-group/--end-group
-# tells the linker to rescan archives until all symbols are resolved.
-# Only .a basenames are wrapped — plain -l flags (e.g. -lc, -lm) are left as-is.
+# In IDF 6.x, the mbedtls component family has circular cross-library dependencies
+# (libtfpsacrypto.a needs symbols from libmbed-builtin.a and vice versa).
+# SCons places LIBS after LINKFLAGS in the link command. The --start-group/--end-group
+# flags from CMake's extra_flags sit in LINKFLAGS and do NOT wrap the LIBS list.
+# Fix: patch LINKCOM to wrap $_LIBFLAGS with group markers so all libs are rescanned.
+_linkcom = env.get("LINKCOM", "")
+if "$_LIBFLAGS" in str(_linkcom) and "-Wl,--start-group" not in str(_linkcom):
+    env.Replace(
+        LINKCOM=str(_linkcom).replace(
+            "$_LIBFLAGS",
+            "-Wl,--start-group $_LIBFLAGS -Wl,--end-group"
+        )
+    )
+
+# Strip --start-group/--end-group from extra_flags since LINKCOM now handles grouping
+extra_flags = [
+    f for f in extra_flags
+    if f not in ("-Wl,--start-group", "-Wl,--end-group")
+]
+
+# Handle precompiled absolute-path archives from extract_link_args/_add_archive.
+# These are .a basenames in link_args["LIBS"] with their dirs in LIBPATH.
+# They are already inside the LINKCOM group via $_LIBFLAGS after MergeFlags.
 all_libs = link_args.get("LIBS", [])
 precompiled_libpaths = link_args.get("LIBPATH", [])
 archive_libs = [lib for lib in all_libs if lib.endswith(".a")]
 plain_libs = [lib for lib in all_libs if not lib.endswith(".a")]
+
 if archive_libs:
-    # Resolve basename -> full path so the linker finds each archive directly
-    libpath_libs_flags = []
+    # Resolve to full paths. Add to LIBS (not LINKFLAGS) so they land inside
+    # the --start-group/$_LIBFLAGS/--end-group wrapper in LINKCOM.
+    resolved_archives = []
     for lib in archive_libs:
         full_path = None
         for lp in precompiled_libpaths:
@@ -2799,17 +2818,12 @@ if archive_libs:
             if os.path.isfile(candidate):
                 full_path = candidate
                 break
-        libpath_libs_flags.append(full_path if full_path else "-l:%s" % lib)
-
-    # Move the precompiled archives into LINKFLAGS inside a group so the
-    # linker rescans them until all cross-library dependencies are resolved
-    link_args["LINKFLAGS"] = link_args.get("LINKFLAGS", []) + (
-        ["-Wl,--start-group"] + libpath_libs_flags + ["-Wl,--end-group"]
-    )
-    # Keep plain -l flags in LIBS; only remove the .a entries we've handled
-    link_args["LIBS"] = plain_libs
-    # Note: keep LIBPATH intact — it contains -L dirs needed by -T linker scripts
-    # (e.g. esp32.peripherals.ld from the ROM ld directory)
+        resolved_archives.append(full_path if full_path else lib)
+    # Replace bare basenames with resolved paths and add back as plain entries
+    # SCons treats strings in LIBS as -l<name> unless the name contains a path sep
+    # or ends in .a — full paths are passed as-is to the linker.
+    link_args["LIBS"] = plain_libs + resolved_archives
+    # Keep LIBPATH for -L dirs needed by -T linker scripts
 
 project_flags.update(link_args)
 env.MergeFlags(link_args)

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2779,6 +2779,34 @@ env.Depends("$BUILD_DIR/$PROGNAME$PROGSUFFIX", partition_table)
 # Main environment configuration
 #
 
+# Precompiled absolute-path archives (e.g. libtfpsacrypto.a, libmbedcrypto.a)
+# are appended to LIBS via extract_link_args/_add_archive in CMake order.
+# In IDF 6.x, tf-psa-crypto depends on mbedtls symbols but may appear before
+# them in the CMake commandFragments. Wrapping them in --start-group/--end-group
+# tells the linker to rescan archives until all symbols are resolved.
+precompiled_libs = link_args.get("LIBS", [])
+precompiled_libpaths = link_args.get("LIBPATH", [])
+if precompiled_libs:
+    # Resolve basename -> full path so we can pass absolute paths directly
+    libpath_libs_flags = []
+    for lib in precompiled_libs:
+        full_path = None
+        for lp in precompiled_libpaths:
+            candidate = os.path.join(lp, lib)
+            if os.path.isfile(candidate):
+                full_path = candidate
+                break
+        libpath_libs_flags.append(full_path if full_path else "-l:%s" % lib)
+
+    # Move the precompiled archives into LINKFLAGS inside a group so the
+    # linker rescans them until all cross-library dependencies are resolved
+    link_args["LINKFLAGS"] = link_args.get("LINKFLAGS", []) + (
+        ["-Wl,--start-group"] + libpath_libs_flags + ["-Wl,--end-group"]
+    )
+    link_args["LIBS"] = []
+    # Note: keep LIBPATH intact — it contains -L dirs needed by -T linker scripts
+    # (e.g. esp32.peripherals.ld from the ROM ld directory)
+
 project_flags.update(link_args)
 env.MergeFlags(link_args)
 env.Prepend(

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2360,7 +2360,7 @@ def _get_python_deps():
         # https://github.com/platformio/platform-espressif32/issues/635
         "cryptography": "~=44.0.0",
         "pyparsing": ">=3.1.0,<4",
-        "idf-component-manager": "~=2.4.11",
+        "idf-component-manager": "~=2.5.0",
         "esp-idf-kconfig": "~=3.7.0"
     }
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2246,13 +2246,26 @@ def generate_mbedtls_bundle(sdk_config):
     crt_args = ["--input"]
     if sdk_config.get("MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL", False):
         crt_args.append(str(Path(default_crt_dir) / "cacrt_all.pem"))
-        crt_args.append(str(Path(default_crt_dir) / "cacrt_local.pem"))
     elif sdk_config.get("MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN", False):
         crt_args.append(str(Path(default_crt_dir) / "cacrt_all.pem"))
-        crt_args.append(str(Path(default_crt_dir) / "cacrt_local.pem"))
         cmd.extend(
             ["--filter", str(Path(default_crt_dir) / "cmn_crt_authorities.csv")]
         )
+
+    # Currently cacrt_local.pem contains deprecated certificates that are still required for certain certificate chains.
+    # These chains may include cross-signed certificates, but the final certificate in the chain is deprecated.
+    # When cross-signed verification is enabled (CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_CROSS_SIGNED_VERIFY),
+    # the cross-signed certificate should be sufficient for verification, and the deprecated root is not needed.
+    # Therefore, cacrt_local.pem is only appended if cross-signed verification is not enabled.
+    if (sdk_config.get("MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL", False) or 
+        sdk_config.get("MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN", False)) and \
+        not sdk_config.get("MBEDTLS_CERTIFICATE_BUNDLE_CROSS_SIGNED_VERIFY", False):
+        crt_args.append(str(Path(default_crt_dir) / "cacrt_local.pem"))
+
+    # Add deprecated root certs if enabled. This config is not visible if the default cert
+    # bundle is not selected
+    if sdk_config.get("MBEDTLS_CERTIFICATE_BUNDLE_DEPRECATED_LIST", False):
+        crt_args.append(str(Path(default_crt_dir) / "cacrt_deprecated.pem"))
 
     if sdk_config.get("MBEDTLS_CUSTOM_CERTIFICATE_BUNDLE", False):
         cert_path = sdk_config.get("MBEDTLS_CUSTOM_CERTIFICATE_BUNDLE_PATH", "")
@@ -2260,6 +2273,11 @@ def generate_mbedtls_bundle(sdk_config):
             crt_args.append(os.path.abspath(cert_path))
         else:
             print("Warning! Couldn't find custom certificate bundle %s" % cert_path)
+
+    # Add max-certs parameter if configured
+    max_certs = sdk_config.get("MBEDTLS_CERTIFICATE_BUNDLE_MAX_CERTS", None)
+    if max_certs:
+        crt_args.extend(["--max-certs", str(max_certs)])
 
     crt_args.append("-q")
 

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2779,18 +2779,12 @@ env.Depends("$BUILD_DIR/$PROGNAME$PROGSUFFIX", partition_table)
 # Main environment configuration
 #
 
-# In IDF 6.x, the mbedtls component family has circular cross-library dependencies.
-# SCons places LIBS after LINKFLAGS in the link command, so --start-group/--end-group
-# flags in extra_flags (LINKFLAGS) do NOT wrap the LIBS list.
-# Fix: patch LINKCOM to wrap $_LIBFLAGS with group markers so all libs are rescanned.
-_linkcom = env.get("LINKCOM", "")
-if "$_LIBFLAGS" in str(_linkcom) and "-Wl,--start-group" not in str(_linkcom):
-    env.Replace(
-        LINKCOM=str(_linkcom).replace(
-            "$_LIBFLAGS",
-            "-Wl,--start-group $_LIBFLAGS -Wl,--end-group"
-        )
-    )
+# In IDF 6.x, the mbedtls component family has circular cross-library dependencies
+# (libtfpsacrypto, libmbed-builtin, libmbedtls, libmbedx509 all cross-reference each
+# other). Use the same __RPATH/__LIBDIRFLAGS trick as the bootloader env to wrap
+# all libs in --start-group/--end-group so the linker rescans them.
+env.Prepend(__RPATH="-Wl,--start-group ")
+env.Append(_LIBDIRFLAGS=" -Wl,--end-group")
 
 # Strip --start-group/--end-group from extra_flags to avoid double-wrapping
 extra_flags = [

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1970,28 +1970,40 @@ def build_bootloader(sdk_config):
 
     framework_version_list = [int(v) for v in get_framework_version().split(".")]
     if framework_version_list[:2] >= [6, 0]:
-        # For IDF 6.0+, preprocess bootloader.ld.in via SCons before linking.
-        # CMake's own ninja build handles the other bootloader linker scripts
-        # (e.g. bootloader.sections.ld) through its own CUSTOM_COMMAND targets
-        # with the correct include paths already configured.
-        bootloader_ld_in = str(
-            Path(bootloader_src_dir) / "main" / "ld" / idf_variant / "bootloader.ld.in"
+        # For IDF 6.0+, the bootloader linker scripts are .ld.in templates
+        # (bootloader.memory.ld.in and bootloader.sections.ld.in) that CMake
+        # would normally preprocess via its own CUSTOM_COMMAND targets.
+        # Since PlatformIO does not run the ninja build for the bootloader,
+        # we preprocess them here via SCons instead.
+        #
+        # bootloader.sections.ld.in includes bootloader.sections.common.ld
+        # which lives in the parent ld/ directory, so that directory must be
+        # in the include path alongside the chip-specific subdirectory.
+        ld_src_dir = str(
+            Path(bootloader_src_dir) / "main" / "ld"
         )
-        bootloader_ld_out = str(
-            Path(BUILD_DIR) / "bootloader" / "ld" / "bootloader.ld"
-        )
-        bootloader_linker_script = preprocess_linker_script(
-            bootloader_ld_in,
-            bootloader_ld_out,
-            [
-                str(Path(BUILD_DIR) / "bootloader" / "config"),
-                str(Path(FRAMEWORK_DIR) / "components" / "esp_system" / "ld"),
-            ],
-        )
-        env.Depends(
-            str(Path("$BUILD_DIR") / "bootloader.elf"),
-            bootloader_linker_script,
-        )
+        ld_chip_dir = str(Path(ld_src_dir) / idf_variant)
+        bootloader_config_dir = str(Path(BUILD_DIR) / "bootloader" / "config")
+
+        for ld_in_name in ("bootloader.memory.ld.in", "bootloader.sections.ld.in"):
+            ld_in_path = str(Path(ld_chip_dir) / ld_in_name)
+            if not os.path.isfile(ld_in_path):
+                continue
+            ld_out_name = ld_in_name[:-3]  # strip ".in"
+            ld_out_path = str(Path(BUILD_DIR) / "bootloader" / "ld" / ld_out_name)
+            preprocessed = preprocess_linker_script(
+                ld_in_path,
+                ld_out_path,
+                [
+                    bootloader_config_dir,
+                    ld_src_dir,       # parent ld/ dir: needed for bootloader.sections.common.ld
+                    ld_chip_dir,      # chip-specific dir: needed for any local includes
+                ],
+            )
+            env.Depends(
+                str(Path("$BUILD_DIR") / "bootloader.elf"),
+                preprocessed,
+            )
 
     # Note: By default the size of bootloader is limited to 0x2000 bytes,
     # in debug mode the footprint size can be easily grow beyond this limit

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -2781,10 +2781,10 @@ env.Depends("$BUILD_DIR/$PROGNAME$PROGSUFFIX", partition_table)
 
 # In IDF 6.x, the mbedtls component family has circular cross-library dependencies
 # (libtfpsacrypto, libmbed-builtin, libmbedtls, libmbedx509 all cross-reference each
-# other). Use the same __RPATH/__LIBDIRFLAGS trick as the bootloader env to wrap
-# all libs in --start-group/--end-group so the linker rescans them.
-env.Prepend(__RPATH="-Wl,--start-group ")
-env.Append(_LIBDIRFLAGS=" -Wl,--end-group")
+# other). SCons LIBS nodes go into $_LIBFLAGS in the link command. We wrap $_LIBFLAGS
+# with --start-group/--end-group by overriding _LIBFLAGS to include the group markers.
+_orig_libflags = env.get("_LIBFLAGS", "${_stripixes(LIBLINKPREFIX, LIBS, LIBLINKSUFFIX, LIBPREFIXES, LIBSUFFIXES, __env__)}")
+env.Replace(_LIBFLAGS="-Wl,--start-group %s -Wl,--end-group" % _orig_libflags)
 
 # Strip --start-group/--end-group from extra_flags to avoid double-wrapping
 extra_flags = [

--- a/builder/frameworks/espidf.py
+++ b/builder/frameworks/espidf.py
@@ -1495,9 +1495,13 @@ def generate_project_ld_script(sdk_config, ignore_targets=None):
 
     framework_version_list = [int(v) for v in get_framework_version().split(".")]
     if framework_version_list[:2] > [5, 2]:
-        initial_ld_script = preprocess_linker_file(
+        initial_ld_script = preprocess_linker_script(
             initial_ld_script,
             str(Path(BUILD_DIR) / "esp-idf" / "esp_system" / "ld" / linker_script_name),
+            [
+                str(Path(BUILD_DIR) / "config"),
+                str(Path(FRAMEWORK_DIR) / "components" / "esp_system" / "ld"),
+            ],
         )
 
     ld_script = env.Command(
@@ -1921,68 +1925,6 @@ def find_lib_deps(components_map, elf_config, link_args, ignore_components=None)
     return result
 
 
-def _patch_bootloader_ninja_ld_cflags(bootloader_build_dir, idf_variant):
-    """Patch the bootloader's build.ninja to add the missing include directory for
-    bootloader linker script preprocessing.
-
-    IDF v6.0's utilities.cmake preprocess_linker_file() adds the *parent* of the
-    chip-specific ld directory (e.g. .../main/ld) to CFLAGS, but not the directory
-    itself (.../main/ld/<idf_variant>/).  This means the C preprocessor cannot
-    resolve #include "bootloader.sections.common.ld" inside bootloader.sections.ld.in
-    because that file lives in the chip-specific subdirectory.
-
-    We fix this by scanning build.ninja for every CUSTOM_COMMAND line that references
-    linker_script_preprocessor.cmake and patching its -DCFLAGS= value to also include
-    the chip-specific ld directory.
-    """
-    ninja_file = str(Path(bootloader_build_dir) / "build.ninja")
-    if not os.path.isfile(ninja_file):
-        return
-
-    # The directory that is missing from the include path:
-    # .../components/bootloader/subproject/main/ld/<idf_variant>
-    missing_inc = fs.to_unix_path(str(
-        Path(FRAMEWORK_DIR) / "components" / "bootloader" / "subproject"
-        / "main" / "ld" / idf_variant
-    ))
-
-    with open(ninja_file, encoding="utf-8") as fh:
-        content = fh.read()
-
-    if "linker_script_preprocessor.cmake" not in content:
-        return  # nothing to patch
-
-    if missing_inc in content:
-        return  # already present (incremental build)
-
-    patched_lines = []
-    changed = False
-    for line in content.splitlines(keepends=True):
-        # Only touch build lines that invoke linker_script_preprocessor.cmake
-        if "linker_script_preprocessor.cmake" in line and "-DCFLAGS=" in line:
-            # Insert -I"<missing_inc>" just before the closing quote of -DCFLAGS=
-            # The flag looks like:  -DCFLAGS=-C -I"dir1" ...  (may or may not be quoted)
-            # We append our extra -I at the end of the CFLAGS value, before any
-            # following space-separated cmake argument.
-            #
-            # Strategy: find the -DCFLAGS= token and append our flag after the last
-            # existing -I"..." or right after the = sign if no -I flags exist yet.
-            replacement = ' -I\\"%s\\"' % missing_inc
-            # Insert before the first cmake argument that follows -DCFLAGS=...
-            # i.e. before " -P " which introduces the script path.
-            if " -P " in line:
-                line = line.replace(" -P ", replacement + " -P ", 1)
-                changed = True
-        patched_lines.append(line)
-
-    if changed:
-        with open(ninja_file, "w", encoding="utf-8") as fh:
-            fh.writelines(patched_lines)
-        print(
-            "Patched bootloader build.ninja: added -I\"%s\" to linker script CFLAGS"
-            % missing_inc
-        )
-
 
 def build_bootloader(sdk_config):
     bootloader_src_dir = str(Path(FRAMEWORK_DIR) / "components" / "bootloader" / "subproject")
@@ -2005,10 +1947,6 @@ def build_bootloader(sdk_config):
         ],
     )
 
-    # Fix IDF v6.0 bug: the chip-specific ld dir is missing from CFLAGS in the
-    # ninja CUSTOM_COMMANDs that preprocess bootloader linker scripts.
-    _patch_bootloader_ninja_ld_cflags(bootloader_build_dir, idf_variant)
-
     if not code_model:
         sys.stderr.write("Error: Couldn't find code model for bootloader\n")
         env.Exit(1)
@@ -2030,6 +1968,31 @@ def build_bootloader(sdk_config):
         target_configs, ["STATIC_LIBRARY", "OBJECT_LIBRARY"]
     )
 
+    framework_version_list = [int(v) for v in get_framework_version().split(".")]
+    if framework_version_list[:2] >= [6, 0]:
+        # For IDF 6.0+, preprocess bootloader.ld.in via SCons before linking.
+        # CMake's own ninja build handles the other bootloader linker scripts
+        # (e.g. bootloader.sections.ld) through its own CUSTOM_COMMAND targets
+        # with the correct include paths already configured.
+        bootloader_ld_in = str(
+            Path(bootloader_src_dir) / "main" / "ld" / idf_variant / "bootloader.ld.in"
+        )
+        bootloader_ld_out = str(
+            Path(BUILD_DIR) / "bootloader" / "ld" / "bootloader.ld"
+        )
+        bootloader_linker_script = preprocess_linker_script(
+            bootloader_ld_in,
+            bootloader_ld_out,
+            [
+                str(Path(BUILD_DIR) / "bootloader" / "config"),
+                str(Path(FRAMEWORK_DIR) / "components" / "esp_system" / "ld"),
+            ],
+        )
+        env.Depends(
+            str(Path("$BUILD_DIR") / "bootloader.elf"),
+            bootloader_linker_script,
+        )
+
     # Note: By default the size of bootloader is limited to 0x2000 bytes,
     # in debug mode the footprint size can be easily grow beyond this limit
     build_components(
@@ -2046,82 +2009,7 @@ def build_bootloader(sdk_config):
     )
 
     bootloader_env.MergeFlags(link_args)
-    
-    # Handle ESP-IDF 6.0 linker script preprocessing for .ld.in files
-    # In bootloader context, only .ld.in templates exist and need preprocessing
-    processed_extra_flags = []
-    
-    # Bootloader preprocessing configuration
-    bootloader_config_dir = str(Path(BUILD_DIR) / "bootloader" / "config")
-    bootloader_extra_includes = [
-        str(Path(FRAMEWORK_DIR) / "components" / "bootloader" / "subproject" / "main" / "ld" / idf_variant)
-    ]
-
-    i = 0
-    while i < len(extra_flags):
-        if extra_flags[i] == "-T" and i + 1 < len(extra_flags):
-            linker_script = extra_flags[i + 1]
-            
-            # Process .ld.in templates directly
-            if linker_script.endswith(".ld.in"):
-                script_name = os.path.basename(linker_script).replace(".ld.in", ".ld")
-                target_script = str(Path(BUILD_DIR) / "bootloader" / script_name)
-                
-                preprocessed_script = preprocess_linker_file(
-                    linker_script,
-                    target_script,
-                    config_dir=bootloader_config_dir,
-                    extra_include_dirs=bootloader_extra_includes
-                )
-                
-                bootloader_env.Depends("$BUILD_DIR/bootloader.elf", preprocessed_script)
-                processed_extra_flags.extend(["-T", target_script])
-            # Handle .ld files - prioritize using original scripts when available
-            elif linker_script.endswith(".ld"):
-                script_basename = os.path.basename(linker_script)
-                
-                # Check if the original .ld file exists in framework and use it directly
-                original_script_path = str(Path(FRAMEWORK_DIR) / "components" / "bootloader" / "subproject" / "main" / "ld" / idf_variant / script_basename)
-                
-                if os.path.isfile(original_script_path):
-                    # Use the original script directly - no preprocessing needed
-                    processed_extra_flags.extend(["-T", original_script_path])
-                else:
-                    # Only generate from template if no original .ld file exists
-                    script_name_in = script_basename.replace(".ld", ".ld.in")
-                    bootloader_script_in_path = str(Path(FRAMEWORK_DIR) / "components" / "bootloader" / "subproject" / "main" / "ld" / idf_variant / script_name_in)
-                    
-                    # ESP32-P4 specific: Check for bootloader.rev3.ld.in
-                    if idf_variant == "esp32p4" and chip_variant == "esp32p4" and script_basename == "bootloader.ld":
-                        bootloader_rev3_path = str(Path(FRAMEWORK_DIR) / "components" / "bootloader" / "subproject" / "main" / "ld" / idf_variant / "bootloader.rev3.ld.in")
-                        if os.path.isfile(bootloader_rev3_path):
-                            bootloader_script_in_path = bootloader_rev3_path
-                    
-                    # Preprocess the .ld.in template to generate the .ld file
-                    if os.path.isfile(bootloader_script_in_path):
-                        target_script = str(Path(BUILD_DIR) / "bootloader" / script_basename)
-                        
-                        preprocessed_script = preprocess_linker_file(
-                            bootloader_script_in_path,
-                            target_script,
-                            config_dir=bootloader_config_dir,
-                            extra_include_dirs=bootloader_extra_includes
-                        )
-                        
-                        bootloader_env.Depends("$BUILD_DIR/bootloader.elf", preprocessed_script)
-                        processed_extra_flags.extend(["-T", target_script])
-                    else:
-                        # Pass through if neither original nor template found (e.g., ROM scripts)
-                        processed_extra_flags.extend(["-T", linker_script])
-            else:
-                # Pass through any other linker flags unchanged
-                processed_extra_flags.extend(["-T", linker_script])
-            i += 2
-        else:
-            processed_extra_flags.append(extra_flags[i])
-            i += 1
-    
-    bootloader_env.Append(LINKFLAGS=processed_extra_flags)
+    bootloader_env.Append(LINKFLAGS=extra_flags)
     bootloader_libs = find_lib_deps(components_map, elf_config, link_args)
 
     bootloader_env.Prepend(__RPATH="-Wl,--start-group ")
@@ -2301,82 +2189,37 @@ def get_app_partition_offset(pt_table, pt_offset):
     return factory_app_params.get("offset", "0x10000")
 
 
-def preprocess_linker_file(src_ld_script, target_ld_script, config_dir=None, extra_include_dirs=None):
+def preprocess_linker_script(source_script, target_script, extra_include_dirs=None):
     """
-    Preprocess a linker script file (.ld.in) to generate the final .ld file.
-    Supports both IDF 5.x (linker_script_generator.cmake) and IDF 6.x (linker_script_preprocessor.cmake).
-    
+    Preprocess a linker script template (.ld.in) to generate the final .ld file
+    using CMake's linker_script_preprocessor.cmake (IDF 6.x+).
+
     Args:
-        src_ld_script: Source .ld.in file path
-        target_ld_script: Target .ld file path
-        config_dir: Configuration directory (defaults to BUILD_DIR/config for main app)
-        extra_include_dirs: Additional include directories (list)
+        source_script: Source .ld.in file path
+        target_script: Target .ld file path
+        extra_include_dirs: List of include directories passed as -I flags to
+                            the C preprocessor via -DCFLAGS
     """
-    if config_dir is None:
-        config_dir = str(Path(BUILD_DIR) / "config")
-    
-    # Convert all paths to forward slashes for CMake compatibility on Windows
-    config_dir = fs.to_unix_path(config_dir)
-    src_ld_script = fs.to_unix_path(src_ld_script)
-    target_ld_script = fs.to_unix_path(target_ld_script)
-    
-    # Check IDF version to determine which CMake script to use
-    framework_version_list = [int(v) for v in get_framework_version().split(".")]
-    
-    # IDF 6.0+ uses linker_script_preprocessor.cmake with CFLAGS approach
-    if framework_version_list[0] >= 6:
-        all_include_dirs = [config_dir]
-        all_include_dirs.append(
-            fs.to_unix_path(str(Path(FRAMEWORK_DIR) / "components" / "esp_system" / "ld"))
-        )
-        if extra_include_dirs:
-            all_include_dirs.extend(
-                fs.to_unix_path(d) for d in extra_include_dirs
-            )
+    extra_include_dirs = extra_include_dirs or []
+    cmd = [
+        CMAKE_DIR,
+        "-DCC=%s" % os.path.join(TOOLCHAIN_DIR, "bin", "$CC"),
+        "-DSOURCE=$SOURCE",
+        "-DTARGET=$TARGET",
+        '"-DCFLAGS=%s"' % " ".join(
+            '-I\\"%s\\"' % fs.to_unix_path(inc) for inc in extra_include_dirs
+        ),
+        "-P",
+        fs.to_unix_path(str(
+            Path(FRAMEWORK_DIR) / "tools" / "cmake" / "linker_script_preprocessor.cmake"
+        )),
+    ]
+    return env.Command(
+        target_script,
+        source_script,
+        env.VerboseAction(" ".join(cmd), "Generating LD script $TARGET"),
+    )
 
-        # Each include path is individually escaped so CMake receives:
-        #   -DCFLAGS=-I\"path1\" -I\"path2\"
-        # matching the upstream reference implementation.
-        cflags_value = " ".join(
-            '-I\\"%s\\"' % d for d in all_include_dirs
-        )
-
-        cmd = " ".join([
-            '"%s"' % CMAKE_DIR,
-            '-DCC="$CC"',
-            '-DSOURCE="%s"' % src_ld_script,
-            '-DTARGET="%s"' % target_ld_script,
-            '"-DCFLAGS=%s"' % cflags_value,
-            "-P",
-            '"%s"' % fs.to_unix_path(
-                str(Path(FRAMEWORK_DIR) / "tools" / "cmake" / "linker_script_preprocessor.cmake")
-            ),
-        ])
-
-        return env.Command(
-            target_ld_script,
-            src_ld_script,
-            env.VerboseAction(cmd, "Generating LD script $TARGET"),
-        )
-    else:
-        # IDF 5.x: Use legacy linker_script_generator.cmake method
-        return env.Command(
-            target_ld_script,
-            src_ld_script,
-            env.VerboseAction(
-                " ".join([
-                    f'"{CMAKE_DIR}"',
-                    '-DCC="$CC"',
-                    "-DSOURCE=$SOURCE",
-                    "-DTARGET=$TARGET",
-                    f'-DCONFIG_DIR="{config_dir}"',
-                    f'-DLD_DIR="{str(Path(FRAMEWORK_DIR) / "components" / "esp_system" / "ld")}"',
-                    "-P",
-                    f'"{str(Path("$BUILD_DIR") / "esp-idf" / "esp_system" / "ld" / "linker_script_generator.cmake")}"',
-                ]),
-                "Generating LD script $TARGET",
-            ),
-        )
 
 
 def generate_mbedtls_bundle(sdk_config):
@@ -2649,9 +2492,13 @@ if not board.get("build.ldscript", ""):
 
     framework_version_list = [int(v) for v in get_framework_version().split(".")]
     if framework_version_list[:2] > [5, 2]:
-        initial_ld_script = preprocess_linker_file(
+        initial_ld_script = preprocess_linker_script(
             initial_ld_script,
-            str(Path(BUILD_DIR) / "esp-idf" / "esp_system" / "ld" / "memory.ld.in")
+            str(Path(BUILD_DIR) / "esp-idf" / "esp_system" / "ld" / "memory.ld.in"),
+            [
+                str(Path(BUILD_DIR) / "config"),
+                str(Path(FRAMEWORK_DIR) / "components" / "esp_system" / "ld"),
+            ],
         )
 
     linker_script = env.Command(

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -20,7 +20,6 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp-dsp
                           espressif/esp32-camera
                           joltwallet/littlefs
-                          espressif/fb_gfx
 
 [env:esp32s3-qio_opi_per]
 ; OPI Performance settings -> Display use
@@ -49,7 +48,6 @@ custom_component_remove     = espressif/esp_hosted
                               espressif/esp_diagnostics
                               espressif/esp_rainmaker
                               espressif/rmaker_common
-                              espressif/fb_gfx
 
 [env:esp32-c2-devkitm-1]
 platform = espressif32
@@ -65,7 +63,6 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp_modem
                           espressif/esp32-camera
                           joltwallet/littlefs
-                          espressif/fb_gfx
  
 [env:esp32-c6-devkitc-1]
 platform = espressif32
@@ -82,7 +79,6 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp_modem
                           espressif/esp32-camera
                           joltwallet/littlefs
-                          espressif/fb_gfx
 
 [env:esp32-c61-devkitc1-n8r2]
 platform = espressif32
@@ -99,7 +95,6 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp_modem
                           espressif/esp32-camera
                           joltwallet/littlefs
-                          espressif/fb_gfx
 
 [env:esp32-h2-devkitm-1]
 platform = espressif32
@@ -115,7 +110,6 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp_modem
                           espressif/esp32-camera
                           joltwallet/littlefs
-                          espressif/fb_gfx
 
 [env:esp32-p4]
 platform = espressif32
@@ -132,4 +126,3 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp_modem
                           espressif/esp32-camera
                           joltwallet/littlefs
-                          espressif/fb_gfx

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -29,7 +29,8 @@ framework = arduino
 board = esp32s3_120_16_8-qio_opi
 lib_ignore                  = ble
                               wifi
-custom_sdkconfig            = CONFIG_LCD_RGB_ISR_IRAM_SAFE=y
+custom_sdkconfig            = CONFIG_LIBC_PICOLIBC=y
+                              CONFIG_LCD_RGB_ISR_IRAM_SAFE=y
                               CONFIG_GDMA_CTRL_FUNC_IN_IRAM=y
                               CONFIG_I2S_ISR_IRAM_SAFE=y
                               CONFIG_GDMA_ISR_IRAM_SAFE=y

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -20,6 +20,7 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp-dsp
                           espressif/esp32-camera
                           joltwallet/littlefs
+                          espressif/fb_gfx
 
 [env:esp32s3-qio_opi_per]
 ; OPI Performance settings -> Display use
@@ -47,6 +48,7 @@ custom_component_remove     = espressif/esp_hosted
                               espressif/esp_diagnostics
                               espressif/esp_rainmaker
                               espressif/rmaker_common
+                              espressif/fb_gfx
 
 [env:esp32-c2-devkitm-1]
 platform = espressif32
@@ -62,6 +64,7 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp_modem
                           espressif/esp32-camera
                           joltwallet/littlefs
+                          espressif/fb_gfx
  
 [env:esp32-c6-devkitc-1]
 platform = espressif32
@@ -78,6 +81,7 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp_modem
                           espressif/esp32-camera
                           joltwallet/littlefs
+                          espressif/fb_gfx
 
 [env:esp32-c61-devkitc1-n8r2]
 platform = espressif32
@@ -94,6 +98,7 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp_modem
                           espressif/esp32-camera
                           joltwallet/littlefs
+                          espressif/fb_gfx
 
 [env:esp32-h2-devkitm-1]
 platform = espressif32
@@ -109,6 +114,7 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp_modem
                           espressif/esp32-camera
                           joltwallet/littlefs
+                          espressif/fb_gfx
 
 [env:esp32-p4]
 platform = espressif32
@@ -125,3 +131,4 @@ custom_component_remove = espressif/esp_hosted
                           espressif/esp_modem
                           espressif/esp32-camera
                           joltwallet/littlefs
+                          espressif/fb_gfx

--- a/examples/espidf-coap-server/src/idf_component.yml
+++ b/examples/espidf-coap-server/src/idf_component.yml
@@ -1,4 +1,4 @@
 dependencies:
-  idf: ">=5.0,<5.6"
+  idf: ">=5.0,<6.2"
   espressif/coap:
     version: "^4.3.5~3"

--- a/examples/espidf-peripherals-usb/src/idf_component.yml
+++ b/examples/espidf-peripherals-usb/src/idf_component.yml
@@ -1,4 +1,4 @@
 ## IDF Component Manager Manifest File
 dependencies:
   espressif/esp_tinyusb: "^1"
-  idf: "^5.0"
+  idf: ">=5.0,<6.2"

--- a/platform.json
+++ b/platform.json
@@ -33,7 +33,7 @@
       "type": "framework",
       "optional": true,
       "owner": "tasmota",
-      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/2808-1345-6.1.0/framework-arduinoespressif32-v6.1.0-c7a6610e.tar.xz"
+      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/2808-1602-6.1.0/framework-arduinoespressif32-v6.1.0-c7a6610e.tar.xz"
     },
     "framework-espidf": {
       "type": "framework",

--- a/platform.json
+++ b/platform.json
@@ -18,7 +18,7 @@
     "type": "git",
     "url": "https://github.com/tasmota/platform-espressif32.git"
   },
-  "version": "2026.08.50",
+  "version": "2026.08.60",
   "frameworks": {
     "arduino": {
       "script": "builder/frameworks/arduino.py"
@@ -33,13 +33,13 @@
       "type": "framework",
       "optional": true,
       "owner": "tasmota",
-      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/2708-1939-5.5.5/framework-arduinoespressif32-v5.5.5-a63b839f.tar.xz"
+      "version": "https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/2808-1345-6.1.0/framework-arduinoespressif32-v6.1.0-c7a6610e.tar.xz"
     },
     "framework-espidf": {
       "type": "framework",
       "optional": true,
       "owner": "tasmota",
-      "version": "https://github.com/tasmota/esp-idf/releases/download/v5.5.5/esp-idf-v5.5.5.tar.xz"
+      "version": "https://github.com/tasmota/esp-idf/releases/download/v6.1.0/esp-idf-v6.1.0.tar.xz"
     },
     "toolchain-xtensa-esp-elf": {
       "type": "toolchain",


### PR DESCRIPTION
## Summary
- Add cross-signed verification check to conditionally include cacrt_local.pem
- Add support for deprecated certificates via MBEDTLS_CERTIFICATE_BUNDLE_DEPRECATED_LIST
- Add --max-certs parameter with MBEDTLS_CERTIFICATE_BUNDLE_MAX_CERTS config
- Remove unconditional inclusion of cacrt_local.pem in both FULL and CMN modes

## Details
The mbedtls certificate bundle generation in espidf.py was missing several features present in the reference esp-idf v6.1.0 CMakeLists.txt implementation. These changes align the PlatformIO implementation with the official esp-idf build system, ensuring proper certificate bundle generation for various security configurations.

Reference: https://github.com/tasmota/esp-idf/tree/v6.1.0/components/mbedtls

#### Test plan
- Python syntax validation passed
- Code changes align with reference implementation from esp-idf v6.1.0
- No breaking changes to existing functionality

Generated with [Devin](https://devin.ai)